### PR TITLE
add argument --ldap-filter

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -26,6 +26,7 @@ pub struct Options {
     pub kerberos: bool,
     pub zip: bool,
     pub verbose: log::LevelFilter,
+    pub ldap_filter: String,
 }
 
 #[derive(Clone, Debug)]
@@ -153,7 +154,14 @@ fn cli() -> Command {
             .required(false)
             .action(ArgAction::SetTrue)
             .global(false)
-        );
+        )
+        .arg(Arg::new("ldap-filter")
+             .long("ldap-filter")
+             .help("Use custom ldap-filter default is : (objectClass=*)")
+             .required(false)
+             .value_parser(value_parser!(String))
+             .default_missing_value("(objectClass=*)")
+         );
         // Return Command args
         cmd
 }
@@ -197,6 +205,7 @@ pub fn extract_args() -> Options {
         "DCOnly"    => CollectionMethod::DCOnly,
          _          => CollectionMethod::All,
     };
+    let ldap_filter = matches.get_one::<String>("ldap-filter").map(|s| s.as_str()).unwrap_or("(objectClass=*)");
 
     // Return all
     Options {
@@ -215,6 +224,7 @@ pub fn extract_args() -> Options {
         kerberos: kerberos,
         zip: z,
         verbose: v,
+        ldap_filter: ldap_filter.to_string(),
     }
 }
 
@@ -273,5 +283,6 @@ pub fn auto_args() -> Options {
         kerberos: true,
         zip: true,
         verbose: log::LevelFilter::Info,
+        ldap_filter: "(objectClass=*)".to_string()
     }
 }

--- a/src/ldap.rs
+++ b/src/ldap.rs
@@ -35,6 +35,7 @@ pub async fn ldap_search(
     username: &String,
     password: &String,
     kerberos: bool,
+    ldapfilter: &String,
 ) -> Result<Vec<SearchEntry>, Box<dyn Error>> {
     // Construct LDAP args
     let ldap_args = ldap_constructor(ldaps, ip, port, domain, ldapfqdn, username, password, kerberos)?;
@@ -109,7 +110,10 @@ pub async fn ldap_search(
             // } else {
             //     _s_filter = "(objectClass=*)";
             // }
-            let _s_filter = "(objectClass=*)";
+            //let _s_filter = "(objectClass=*)";
+            //let _s_filter = "(objectGuid=*)";
+            info!("Ldap filter : {}", ldapfilter.bold().green());
+            let _s_filter = ldapfilter;
     
             // Every 999 max value in ldap response (err 4 ldap)
             let adapters: Vec<Box<dyn Adapter<_,_>>> = vec![

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         &common_args.username,
         &common_args.password,
         common_args.kerberos,
+        &common_args.ldap_filter
     ).await?;
 
     // Vector for content all


### PR DESCRIPTION
 to change the ldap-filter to use instead of the default (objectClass=*)
 
default : 
![image](https://github.com/user-attachments/assets/99bbb7c3-913e-4190-a01f-3c938bb0ec94)

with argument :
![image](https://github.com/user-attachments/assets/adbea5d6-b334-4c6f-a150-999c55c74bd8)
