### PR TITLE
Fixed help to show usage

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -199,6 +199,8 @@ cd RustHound-CE
 cargo doc --open --no-deps
 ```
 
+</details>
+
 # Usage
 
 ```bash


### PR DESCRIPTION
Currently when you go to the `HELP.md` file the usage section is under a dropdown because it wasn't properly closed. Closed it and it shows the usage properly.