### PR TITLE
Added dependency installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ docker run --rm -v $PWD:/usr/src/rusthound-ce rusthound-ce linux
 <img alt="Crates.io Version" src="https://img.shields.io/crates/v/rusthound-ce"> <img alt="Crates.io Total Downloads" src="https://img.shields.io/crates/d/rusthound-ce?color=f74c00">
 
 ```bash
+# Install the libkrb5-dev dependency
+sudo apt-get install libkrb5-dev
+
 # Install and/or update RustHound-CE from cargo command
 cargo install rusthound-ce
 ```


### PR DESCRIPTION
Include the dependency installation in the `cargo install` commands.

My build was failing, and it took a few searches to discover that the `libkrb5-dev` package was missing.