### PR TITLE
[Feature] Disk Storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 datas/
 rusthound-ce*
 .vscode
+.rusthound-cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror",
  "time",
 ]
 
@@ -134,7 +134,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror",
  "time",
 ]
 
@@ -440,12 +440,6 @@ dependencies = [
  "libgssapi 0.9.0",
  "windows",
 ]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -1045,7 +1039,7 @@ dependencies = [
  "ring 0.16.20",
  "rustls",
  "rustls-native-certs",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -1893,16 +1887,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
-dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1910,17 +1895,6 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2103,7 +2077,7 @@ dependencies = [
  "once_cell",
  "rand",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror",
  "tinyvec",
  "tokio",
  "tracing",
@@ -2125,7 +2099,7 @@ dependencies = [
  "rand",
  "resolv-conf",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "tracing",
  "trust-dns-proto",
@@ -2730,7 +2704,7 @@ dependencies = [
  "nom",
  "oid-registry 0.6.1",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror",
  "time",
 ]
 
@@ -2747,7 +2721,7 @@ dependencies = [
  "nom",
  "oid-registry 0.7.1",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror",
  "time",
 ]
 
@@ -2851,15 +2825,12 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+checksum = "95ab361742de920c5535880f89bbd611ee62002bf11341d16a5f057bb8ba6899"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "crossbeam-utils",
- "displaydoc",
  "indexmap",
  "memchr",
- "thiserror 2.0.12",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1590,7 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 name = "rusthound-ce"
 version = "2.3.7"
 dependencies = [
+ "bincode",
  "bitflags",
  "chrono",
  "clap",
@@ -2162,6 +2183,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2195,6 +2222,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ lazy_static = "1.4.0"
 indicatif = "0.17"
 x509-parser = "0.16"
 trust-dns-resolver = "0.23"
-zip= { version = "2.2.2", default-features = false }
+zip = { version = "4.2.0", default-features = false }
 rpassword = "7.2"
 ldap3 = { version = "0.11.5", default-features = false }
 winreg = { version = "0.52", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ winreg = { version = "0.52", optional = true }
 sha1 = "0.10"
 regex = "1"
 once_cell = "1.19"
+bincode = "2.0.1"
 
 [features]
 noargs = ["winreg"] # Only available for Windows

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,258 @@
+use std::{collections::HashMap, error::Error};
+
+use indicatif::ProgressBar;
+use ldap3::SearchEntry;
+
+use crate::{
+    args::Options, banner::progress_bar, enums::{get_type, Type, PARSER_MOD_RE1, PARSER_MOD_RE2}, json::{
+        checker::check_all_result,
+    }, 
+    objects::{
+        aiaca::AIACA, certtemplate::CertTemplate, common::parse_unknown, computer::Computer, container::Container, domain::Domain, enterpriseca::EnterpriseCA, fsp::Fsp, gpo::Gpo, group::Group, inssuancepolicie::IssuancePolicie, ntauthstore::NtAuthStore, ou::Ou, rootca::RootCA, trust::Trust, user::User
+    }, 
+    storage::{EntrySource}
+};
+
+#[derive(Default)]
+pub struct ADResults {
+    pub users: Vec<User>,
+    pub groups: Vec<Group>,
+    pub computers: Vec<Computer>,
+    pub ous: Vec<Ou>,
+    pub domains: Vec<Domain>,
+    pub gpos: Vec<Gpo>,
+    pub fsps: Vec<Fsp>,
+    pub containers: Vec<Container>,
+    pub trusts: Vec<Trust>,
+    pub ntauthstores: Vec<NtAuthStore>,
+    pub aiacas: Vec<AIACA>,
+    pub rootcas: Vec<RootCA>,
+    pub enterprisecas: Vec<EnterpriseCA>,
+    pub certtemplates: Vec<CertTemplate>,
+    pub issuancepolicies: Vec<IssuancePolicie>,
+
+    pub mappings: DomainMappings,
+}
+
+#[derive(Default)]
+pub struct DomainMappings {
+    /// DN to SID
+    pub dn_sid: HashMap<String, String>,
+    ///  DN to Type
+    pub sid_type: HashMap<String, String>,
+    /// FQDN to SID
+    pub fqdn_sid: HashMap<String, String>,
+    /// fqdn to an ip address
+    pub fqdn_ip: HashMap<String, String>,
+}
+
+impl ADResults {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+pub async fn prepare_results_from_source<S: EntrySource>(
+    source: S,
+    options: &Options,
+    total_objects: Option<usize>,
+) -> Result<ADResults, Box<dyn std::error::Error>> {
+    let mut ad_results = parse_result_type_from_source(options, source, total_objects)?;
+
+    // Functions to replace and add missing values
+    check_all_result(
+        options,
+        &mut ad_results.users,
+        &mut ad_results.groups,
+        &mut ad_results.computers,
+        &mut ad_results.ous,
+        &mut ad_results.domains,
+        &mut ad_results.gpos,
+        &mut ad_results.fsps,
+        &mut ad_results.containers,
+        &mut ad_results.trusts,
+        &mut ad_results.ntauthstores,
+        &mut ad_results.aiacas,
+        &mut ad_results.rootcas,
+        &mut ad_results.enterprisecas,
+        &mut ad_results.certtemplates,
+        &mut ad_results.issuancepolicies,
+        &ad_results.mappings.dn_sid,
+        &ad_results.mappings.sid_type,
+        &ad_results.mappings.fqdn_sid,
+        &ad_results.mappings.fqdn_ip,
+    )?;
+
+    Ok(ad_results)
+}
+
+pub fn export_results(
+    common_args: &Options,
+    results: ADResults,
+) -> Result<(), Box<dyn std::error::Error>> {
+    crate::json::maker::make_result(
+        common_args,
+        results.users,
+        results.groups,
+        results.computers,
+        results.ous,
+        results.domains,
+        results.gpos,
+        results.containers,
+        results.ntauthstores,
+        results.aiacas,
+        results.rootcas,
+        results.enterprisecas,
+        results.certtemplates,
+        results.issuancepolicies,
+    )
+}
+
+// for `total_objects`, the total number of objects may not be known if the ldap query was never run
+// (e.g run was resumed from cached results)
+pub fn parse_result_type_from_source(
+    common_args: &Options,
+    source: impl EntrySource,
+    total_objects: Option<usize>,
+) -> Result<ADResults, Box<dyn Error>> {
+    let mut results = ADResults::default();
+    // Domain name
+    let domain = &common_args.domain;
+
+    // Needed for progress bar stats
+    let pb = ProgressBar::new(1);
+    let mut count = 0;
+    let total = total_objects;
+    let mut domain_sid: String = "DOMAIN_SID".to_owned();
+
+    log::info!("Starting the LDAP objects parsing...");
+
+    let output_dir = format!(".rusthound-cache/{domain}");
+    std::fs::create_dir_all(&output_dir)?;
+
+    let dn_sid = &mut results.mappings.dn_sid;
+    let sid_type = &mut results.mappings.sid_type;
+    let fqdn_sid = &mut results.mappings.fqdn_sid;
+    let fqdn_ip = &mut results.mappings.fqdn_ip;
+
+    for entry in source.into_entry_iter() {
+        let entry: SearchEntry = entry?.into();
+        // Start parsing with Type matching
+        let atype = get_type(&entry).unwrap_or(Type::Unknown);
+        match atype {
+            Type::User => {
+                let mut user: User = User::new();
+                user.parse(entry, domain, dn_sid, sid_type, &domain_sid)?;
+                results.users.push(user);
+            }
+            Type::Group => {
+                let mut group = Group::new();
+                group.parse(entry, domain, dn_sid, sid_type, &domain_sid)?;
+                results.groups.push(group);
+            }
+            Type::Computer => {
+                let mut computer = Computer::new();
+                computer.parse(
+                    entry,
+                    domain,
+                    dn_sid,
+                    sid_type,
+                    fqdn_sid,
+                    fqdn_ip,
+                    &domain_sid,
+                )?;
+                results.computers.push(computer);
+            }
+            Type::Ou => {
+                let mut ou = Ou::new();
+                ou.parse(entry, domain, dn_sid, sid_type, &domain_sid)?;
+                results.ous.push(ou);
+            }
+            Type::Domain => {
+                let mut domain_object = Domain::new();
+                let domain_sid_from_domain =
+                    domain_object.parse(entry, domain, dn_sid, sid_type)?;
+                domain_sid = domain_sid_from_domain;
+                results.domains.push(domain_object);
+            }
+            Type::Gpo => {
+                let mut gpo = Gpo::new();
+                gpo.parse(entry, domain, dn_sid, sid_type, &domain_sid)?;
+                results.gpos.push(gpo);
+            }
+            Type::ForeignSecurityPrincipal => {
+                let mut security_principal = Fsp::new();
+                security_principal.parse(entry, domain, dn_sid, sid_type)?;
+                results.fsps.push(security_principal);
+            }
+            Type::Container => {
+                if PARSER_MOD_RE1.is_match(&entry.dn.to_uppercase())
+                    || PARSER_MOD_RE2.is_match(&entry.dn.to_uppercase())
+                {
+                    //trace!("Container not to add: {}",&cloneresult.dn.to_uppercase());
+                    continue;
+                }
+
+                //trace!("Container: {}",&entry.dn.to_uppercase());
+                let mut container = Container::new();
+                container.parse(entry, domain, dn_sid, sid_type, &domain_sid)?;
+                results.containers.push(container);
+            }
+            Type::Trust => {
+                let mut trust = Trust::new();
+                trust.parse(entry, domain)?;
+                results.trusts.push(trust);
+            }
+            Type::NtAutStore => {
+                let mut nt_auth_store = NtAuthStore::new();
+                nt_auth_store.parse(entry, domain, dn_sid, sid_type, &domain_sid)?;
+                results.ntauthstores.push(nt_auth_store);
+            }
+            Type::AIACA => {
+                let mut aiaca = AIACA::new();
+                aiaca.parse(entry, domain, dn_sid, sid_type, &domain_sid)?;
+                results.aiacas.push(aiaca);
+            }
+            Type::RootCA => {
+                let mut root_ca = RootCA::new();
+                root_ca.parse(entry, domain, dn_sid, sid_type, &domain_sid)?;
+                results.rootcas.push(root_ca);
+            }
+            Type::EnterpriseCA => {
+                let mut enterprise_ca = EnterpriseCA::new();
+                enterprise_ca.parse(entry, domain, dn_sid, sid_type, &domain_sid)?;
+                results.enterprisecas.push(enterprise_ca);
+            }
+            Type::CertTemplate => {
+                let mut cert_template = CertTemplate::new();
+                cert_template.parse(entry, domain, dn_sid, sid_type, &domain_sid)?;
+                results.certtemplates.push(cert_template);
+            }
+            Type::IssuancePolicie => {
+                let mut issuance_policie = IssuancePolicie::new();
+                issuance_policie.parse(entry, domain, dn_sid, sid_type, &domain_sid)?;
+                results.issuancepolicies.push(issuance_policie);
+            }
+            Type::Unknown => {
+                let _unknown = parse_unknown(entry, domain);
+            }
+        }
+        // Manage progress bar
+        // Pourcentage (%) = 100 x Valeur partielle/Valeur totale
+        if let Some(total) = total {
+            count += 1;
+            let pourcentage = 100 * count / total;
+            progress_bar(
+                pb.to_owned(),
+                "Parsing LDAP objects".to_string(),
+                pourcentage.try_into()?,
+                "%".to_string(),
+            );
+        }
+    }
+
+    pb.finish_and_clear();
+    log::info!("Parsing LDAP objects finished!");
+    Ok(results)
+}
+

--- a/src/api.rs
+++ b/src/api.rs
@@ -86,28 +86,6 @@ pub async fn prepare_results_from_source<S: EntrySource>(
     Ok(ad_results)
 }
 
-pub fn export_results(
-    common_args: &Options,
-    results: ADResults,
-) -> Result<(), Box<dyn std::error::Error>> {
-    crate::json::maker::make_result(
-        common_args,
-        results.users,
-        results.groups,
-        results.computers,
-        results.ous,
-        results.domains,
-        results.gpos,
-        results.containers,
-        results.ntauthstores,
-        results.aiacas,
-        results.rootcas,
-        results.enterprisecas,
-        results.certtemplates,
-        results.issuancepolicies,
-    )
-}
-
 // for `total_objects`, the total number of objects may not be known if the ldap query was never run
 // (e.g run was resumed from cached results)
 pub fn parse_result_type_from_source(

--- a/src/enums/ldaptype.rs
+++ b/src/enums/ldaptype.rs
@@ -1,5 +1,4 @@
 use ldap3::SearchEntry;
-use std::collections::HashMap;
 //use log::trace;
 
 /// Enum to get ldap object type.
@@ -23,8 +22,8 @@ pub enum Type {
 }
 
 /// Get object type, like ("user","group","computer","ou", "container", "gpo", "domain" "trust").
-pub fn get_type(result: SearchEntry) -> std::result::Result<Type, Type> {
-    let result_attrs: HashMap<String, Vec<String>> = result.attrs;
+pub fn get_type(result: &SearchEntry) -> std::result::Result<Type, Type> {
+    let result_attrs = &result.attrs;
 
     let contains = |values: &Vec<String>, to_find: &str| values.iter().any(|elem| elem == to_find);
     let object_class_vals = result_attrs.get("objectClass");

--- a/src/json/checker/mod.rs
+++ b/src/json/checker/mod.rs
@@ -41,10 +41,10 @@ pub fn check_all_result(
     vec_enterprisecas:       &mut [EnterpriseCA],
     vec_certtemplates:       &mut [CertTemplate],
     vec_issuancepolicies:    &mut [IssuancePolicie],
-    dn_sid:                  &mut HashMap<String, String>,
-    sid_type:                &mut HashMap<String, String>,
-    fqdn_sid:                &mut HashMap<String, String>,
-    _fqdn_ip:                &mut HashMap<String, String>,
+    dn_sid:                  &HashMap<String, String>,
+    sid_type:                &HashMap<String, String>,
+    fqdn_sid:                &HashMap<String, String>,
+    _fqdn_ip:                &HashMap<String, String>,
 ) -> Result<(), Box<dyn Error>> {
     let domain = &common_args.domain;
     info!("Starting checker to replace some values...");

--- a/src/json/maker/mod.rs
+++ b/src/json/maker/mod.rs
@@ -2,42 +2,13 @@ use std::collections::HashMap;
 use std::error::Error;
 
 extern crate zip;
+use crate::api::ADResults;
 use crate::args::Options;
 use crate::utils::date::return_current_fulldate;
-use crate::objects::{
-   user::User,
-   computer::Computer,
-   group::Group,
-   ou::Ou,
-   container::Container,
-   gpo::Gpo,
-   domain::Domain,
-   ntauthstore::NtAuthStore,
-   aiaca::AIACA,
-   rootca::RootCA,
-   enterpriseca::EnterpriseCA,
-   certtemplate::CertTemplate,
-   inssuancepolicie::IssuancePolicie,
-};
 pub mod common;
 
 /// This function will create json output and zip output
-pub fn make_result(
-   common_args:            &Options,
-   vec_users:              Vec<User>,
-   vec_groups:             Vec<Group>,
-   vec_computers:          Vec<Computer>,
-   vec_ous:                Vec<Ou>,
-   vec_domains:            Vec<Domain>,
-   vec_gpos:               Vec<Gpo>,
-   vec_containers:         Vec<Container>,
-   vec_ntauthstores:       Vec<NtAuthStore>,
-   vec_aiacas:             Vec<AIACA>,
-   vec_rootcas:            Vec<RootCA>,
-   vec_enterprisecas:      Vec<EnterpriseCA>,
-   vec_certtemplates:      Vec<CertTemplate>,
-   vec_issuancepolicies:   Vec<IssuancePolicie>,
-) -> Result<(), Box<dyn Error>> {
+pub fn make_result(common_args: &Options, ad_results: ADResults) -> Result<(), Box<dyn Error>> {
    // Format domain name
    let filename = common_args.domain.replace(".", "-").to_lowercase();
 
@@ -52,7 +23,7 @@ pub fn make_result(
       &datetime,
       "users".to_string(),
 		&filename,
-      vec_users,
+      ad_results.users,
       &mut json_result,
       common_args,
    )?;
@@ -60,7 +31,7 @@ pub fn make_result(
       &datetime,
       "groups".to_string(),
 		&filename,
-      vec_groups,
+      ad_results.groups,
       &mut json_result,
       common_args,
    )?;
@@ -68,7 +39,7 @@ pub fn make_result(
       &datetime,
       "computers".to_string(),
 		&filename,
-      vec_computers,
+      ad_results.computers,
       &mut json_result,
       common_args,
    )?;
@@ -76,7 +47,7 @@ pub fn make_result(
       &datetime,
       "ous".to_string(),
 		&filename,
-      vec_ous,
+      ad_results.ous,
       &mut json_result,
       common_args,
    )?;
@@ -84,7 +55,7 @@ pub fn make_result(
       &datetime,
       "domains".to_string(),
 		&filename,
-      vec_domains,
+      ad_results.domains,
       &mut json_result,
       common_args,
    )?;
@@ -92,7 +63,7 @@ pub fn make_result(
       &datetime,
       "gpos".to_string(),
       &filename,
-      vec_gpos,
+      ad_results.gpos,
       &mut json_result,
       common_args,
    )?;
@@ -101,7 +72,7 @@ pub fn make_result(
       &datetime,
       "containers".to_string(),
 		&filename,
-      vec_containers,
+      ad_results.containers,
       &mut json_result,
       common_args,
    )?;
@@ -109,7 +80,7 @@ pub fn make_result(
       &datetime,
       "ntauthstores".to_string(),
 		&filename,
-      vec_ntauthstores,
+      ad_results.ntauthstores,
       &mut json_result,
       common_args,
    )?;
@@ -117,7 +88,7 @@ pub fn make_result(
       &datetime,
       "aiacas".to_string(),
 		&filename,
-      vec_aiacas,
+      ad_results.aiacas,
       &mut json_result,
       common_args,
    )?;
@@ -125,7 +96,7 @@ pub fn make_result(
       &datetime,
       "rootcas".to_string(),
 		&filename,
-      vec_rootcas,
+      ad_results.rootcas,
       &mut json_result,
       common_args,
    )?;
@@ -133,7 +104,7 @@ pub fn make_result(
       &datetime,
       "enterprisecas".to_string(),
 		&filename,
-      vec_enterprisecas,
+      ad_results.enterprisecas,
       &mut json_result,
       common_args,
    )?;
@@ -141,7 +112,7 @@ pub fn make_result(
       &datetime,
       "certtemplates".to_string(),
 		&filename,
-      vec_certtemplates,
+      ad_results.certtemplates,
       &mut json_result,
       common_args,
    )?;
@@ -149,7 +120,7 @@ pub fn make_result(
       &datetime,
       "issuancepolicies".to_string(),
 		&filename,
-      vec_issuancepolicies,
+      ad_results.issuancepolicies,
       &mut json_result,
       common_args,
    )?;

--- a/src/json/parser/mod.rs
+++ b/src/json/parser/mod.rs
@@ -70,7 +70,7 @@ pub fn parse_result_type(
         // Start parsing with Type matching
         let cloneresult = entry.clone();
         //println!("{:?}",&entry);
-        let atype = get_type(entry).unwrap_or(Type::Unknown);
+        let atype = get_type(&entry).unwrap_or(Type::Unknown);
         match atype {
             Type::User => {
                 let mut user: User = User::new();

--- a/src/ldap.rs
+++ b/src/ldap.rs
@@ -200,8 +200,6 @@ pub async fn ldap_search<S: Storage<LdapSearchEntry>>(
 
     storage.flush()?;
 
-    // reopen file handle
-    // let cache_handle = CacheHandle(rs.into_reader()?);
 
     // Return the vector with the result
     Ok(total)

--- a/src/ldap.rs
+++ b/src/ldap.rs
@@ -6,7 +6,7 @@
 //!
 //! Example in rust
 //!
-//! ```
+//! ```ignore
 //! let search = ldap_search(...)
 //! ```
 

--- a/src/ldap.rs
+++ b/src/ldap.rs
@@ -12,6 +12,7 @@
 
 // use crate::errors::Result;
 use crate::banner::progress_bar;
+use crate::storage::Storage;
 use crate::utils::format::domain_to_dc;
 
 use colored::Colorize;
@@ -26,64 +27,81 @@ use std::error::Error;
 use std::process;
 
 /// Function to request all AD values.
-pub async fn ldap_search(
+#[allow(clippy::too_many_arguments)]
+pub async fn ldap_search<S: Storage<LdapSearchEntry>>(
     ldaps: bool,
     ip: Option<&str>,
-    port: &Option<u16>,
+    port: Option<u16>,
     domain: &str,
     ldapfqdn: &str,
     username: Option<&str>,
     password: Option<&str>,
     kerberos: bool,
     ldapfilter: &str,
-) -> Result<Vec<SearchEntry>, Box<dyn Error>> {
+    storage: &mut S,
+) -> Result<usize, Box<dyn Error>> {
     // Construct LDAP args
-    let ldap_args = ldap_constructor(ldaps, ip, port, domain, ldapfqdn, username, password, kerberos)?;
+    let ldap_args = ldap_constructor(
+        ldaps, ip, port, domain, ldapfqdn, username, password, kerberos,
+    )?;
 
     // LDAP connection
-    let consettings = LdapConnSettings::new().set_no_tls_verify(true);
+    let consettings = LdapConnSettings::new()
+        .set_conn_timeout(std::time::Duration::from_secs(10))
+        .set_no_tls_verify(true);
     let (conn, mut ldap) = LdapConnAsync::with_settings(consettings, &ldap_args.s_url).await?;
     ldap3::drive!(conn);
 
     if !kerberos {
         debug!("Trying to connect with simple_bind() function (username:password)");
-        let res = ldap.simple_bind(&ldap_args.s_username, &ldap_args.s_password).await?.success();
+        let res = ldap
+            .simple_bind(&ldap_args.s_username, &ldap_args.s_password)
+            .await?
+            .success();
         match res {
             Ok(_res) => {
-                info!("Connected to {} Active Directory!", domain.to_uppercase().bold().green());
+                info!(
+                    "Connected to {} Active Directory!",
+                    domain.to_uppercase().bold().green()
+                );
                 info!("Starting data collection...");
-            },
+            }
             Err(err) => {
-                error!("Failed to authenticate to {} Active Directory. Reason: {err}\n", domain.to_uppercase().bold().red());
+                error!(
+                    "Failed to authenticate to {} Active Directory. Reason: {err}\n",
+                    domain.to_uppercase().bold().red()
+                );
                 process::exit(0x0100);
             }
         }
-    }
-    else
-    {
+    } else {
         debug!("Trying to connect with sasl_gssapi_bind() function (kerberos session)");
         if !&ldapfqdn.contains("not set") {
             #[cfg(not(feature = "nogssapi"))]
-            gssapi_connection(&mut ldap,&ldapfqdn,&domain).await?;
-            #[cfg(feature = "nogssapi")]{
+            gssapi_connection(&mut ldap, &ldapfqdn, &domain).await?;
+            #[cfg(feature = "nogssapi")]
+            {
                 error!("Kerberos auth and GSSAPI not compatible with current os!");
                 process::exit(0x0100);
             }
         } else {
-            error!("Need Domain Controller FQDN to bind GSSAPI connection. Please use '{}'\n", "-f DC01.DOMAIN.LAB".bold());
+            error!(
+                "Need Domain Controller FQDN to bind GSSAPI connection. Please use '{}'\n",
+                "-f DC01.DOMAIN.LAB".bold()
+            );
             process::exit(0x0100);
         }
     }
 
-    // Prepare LDAP result vector
-    let mut rs: Vec<SearchEntry> = Vec::new();
+    // // Prepare LDAP result vector
+    let mut total = 0; // for progress bar
 
     // Request all namingContexts for current DC
     let res = match get_all_naming_contexts(&mut ldap).await {
         Ok(res) => {
             trace!("naming_contexts: {:?}", &res);
             res
-        },
+        }
         Err(err) => {
             error!("No namingContexts found! Reason: {err}\n");
             process::exit(0x0100);
@@ -102,7 +120,7 @@ pub async fn ldap_search(
                 val: Some(vec![48, 3, 2, 1, 5]),
             };
             ldap.with_controls(ctrls.to_owned());
-    
+
             // Prepare filter
             // let mut _s_filter: &str = "";
             // if cn.contains("Configuration") {
@@ -114,57 +132,79 @@ pub async fn ldap_search(
             //let _s_filter = "(objectGuid=*)";
             info!("Ldap filter : {}", ldapfilter.bold().green());
             let _s_filter = ldapfilter;
-    
+
             // Every 999 max value in ldap response (err 4 ldap)
-            let adapters: Vec<Box<dyn Adapter<_,_>>> = vec![
+            let adapters: Vec<Box<dyn Adapter<_, _>>> = vec![
                 Box::new(EntriesOnly::new()),
                 Box::new(PagedResults::new(999)),
             ];
-    
+
             // Streaming search with adaptaters and filters
-            let mut search = ldap.streaming_search_with(
-                adapters, // Adapter which fetches Search results with a Paged Results control.
-                cn, 
-                Scope::Subtree,
-                _s_filter,
-                vec!["*", "nTSecurityDescriptor"], 
-                // Without the presence of this control, the server returns an SD only when the SD attribute name is explicitly mentioned in the requested attribute list.
-                // https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/932a7a8d-8c93-4448-8093-c79b7d9ba499
-            ).await?;
-    
+            let mut search = ldap
+                .streaming_search_with(
+                    adapters, // Adapter which fetches Search results with a Paged Results control.
+                    cn,
+                    Scope::Subtree,
+                    _s_filter,
+                    vec!["*", "nTSecurityDescriptor"],
+                    // Without the presence of this control, the server returns an SD only when the SD attribute name is explicitly mentioned in the requested attribute list.
+                    // https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/932a7a8d-8c93-4448-8093-c79b7d9ba499
+                )
+                .await?;
+
             // Wait and get next values
             let pb = ProgressBar::new(1);
-            let mut count = 0;	
+            let mut count = 0;
             while let Some(entry) = search.next().await? {
                 let entry = SearchEntry::construct(entry);
                 //trace!("{:?}", &entry);
+                total += 1;
                 // Manage progress bar
                 count += 1;
-                progress_bar(pb.to_owned(),"LDAP objects retrieved".to_string(),count,"#".to_string());	
-                // Push all result in rs vec()
-                rs.push(entry);
+                progress_bar(
+                    pb.to_owned(),
+                    "LDAP objects retrieved".to_string(),
+                    count,
+                    "#".to_string(),
+                );
+
+                storage.add(entry.into())?;
             }
             pb.finish_and_clear();
-    
+
             let res = search.finish().await.success();
             match res {
-                Ok(_res) => info!("All data collected for NamingContext {}",&cn.bold()),
+                Ok(_res) => info!("All data collected for NamingContext {}", &cn.bold()),
                 Err(err) => {
-                    error!("No data collected on {}! Reason: {err}",&cn.bold().red());
+                    error!("No data collected on {}! Reason: {err}", &cn.bold().red());
                 }
             }
         }
-        // If no result exit program
-        if rs.is_empty() {
-            process::exit(0x0100);
-        }
-    
-        // Terminate the connection to the server
+        // // If no result exit program
+        // if rs.is_empty() {
+        //     process::exit(0x0100);
+        // }
+
         ldap.unbind().await?;
     }
-    
+
+    // drop ldap before final flush,
+    // otherwise it will warn about an i/o error
+    // "LDAP connection error: I/O error: Connection reset by peer (os error 54)"
+    drop(ldap);
+    if total == 0 {
+        error!("No LDAP objects found! Exiting...");
+        // std::fs::remove_file(cache_path)?; // TODO: return error so we can cleanup cache
+        process::exit(0x0100);
+    }
+
+    storage.flush()?;
+
+    // reopen file handle
+    // let cache_handle = CacheHandle(rs.into_reader()?);
+
     // Return the vector with the result
-    Ok(rs)
+    Ok(total)
 }
 
 /// Structure containing the LDAP connection arguments.
@@ -180,7 +220,7 @@ struct LdapArgs {
 fn ldap_constructor(
     ldaps: bool,
     ip: Option<&str>,
-    port: &Option<u16>,
+    port: Option<u16>,
     domain: &str,
     ldapfqdn: &str,
     username: Option<&str>,
@@ -269,7 +309,7 @@ fn ldap_constructor(
 fn prepare_ldap_url(
     ldaps: bool,
     ip: Option<&str>,
-    port: &Option<u16>,
+    port: Option<u16>,
     domain: &str
 ) -> String {
     let protocol = if ldaps || port.unwrap_or(0) == 636 {
@@ -385,4 +425,35 @@ pub async fn get_all_naming_contexts(
     }
     // Empty result if no namingContexts found
     Ok(Vec::new())
+}
+
+// New type to implement Serialize and Deserialize for SearchEntry
+#[derive(Debug, Clone, bincode::Encode, bincode::Decode)]
+pub struct LdapSearchEntry {
+    /// Entry DN.
+    pub dn: String,
+    /// Attributes.
+    pub attrs: HashMap<String, Vec<String>>,
+    /// Binary-valued attributes.
+    pub bin_attrs: HashMap<String, Vec<Vec<u8>>>,
+}
+
+impl From<SearchEntry> for LdapSearchEntry {
+    fn from(entry: SearchEntry) -> Self {
+        LdapSearchEntry {
+            dn: entry.dn,
+            attrs: entry.attrs,
+            bin_attrs: entry.bin_attrs,
+        }
+    }
+}
+
+impl From<LdapSearchEntry> for SearchEntry {
+    fn from(entry: LdapSearchEntry) -> Self {
+        SearchEntry {
+            dn: entry.dn,
+            attrs: entry.attrs,
+            bin_attrs: entry.bin_attrs,
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub mod utils;
 pub mod enums;
 pub mod json;
 pub mod objects;
-pub mod storage;
+pub (crate) mod storage;
 
 pub (crate) mod api;
 
@@ -103,6 +103,6 @@ pub use ldap::ldap_search;
 pub use ldap3::SearchEntry;
 
 
-pub use api::{export_results, prepare_results_from_source, ADResults, DomainMappings};
-pub use storage::{Storage, EntrySource};
+pub use api::{export_results, prepare_results_from_source};
+pub use storage::{Storage, EntrySource, DiskStorage, DiskStorageReader};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ pub use ldap::ldap_search;
 #[doc(inline)]
 pub use ldap3::SearchEntry;
 
-
-pub use api::{export_results, prepare_results_from_source};
+pub use json::maker::make_result;
+pub use api::prepare_results_from_source;
 pub use storage::{Storage, EntrySource, DiskStorage, DiskStorageReader};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,9 @@ pub mod utils;
 pub mod enums;
 pub mod json;
 pub mod objects;
+pub mod storage;
+
+pub (crate) mod api;
 
 extern crate bitflags;
 extern crate chrono;
@@ -98,3 +101,8 @@ extern crate regex;
 pub use ldap::ldap_search;
 #[doc(inline)]
 pub use ldap3::SearchEntry;
+
+
+pub use api::{export_results, prepare_results_from_source, ADResults, DomainMappings};
+pub use storage::{Storage, EntrySource};
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use log::{error, info, trace};
 
 use rusthound_ce::{
     args, ldap, objects,
-    storage::{BincodeDiskStorage, BincodeFileIterator},
+    DiskStorage, DiskStorageReader,
     utils,
 };
 
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 .join(&common_args.domain)
                 .join(CACHE_FILE);
             info!("Resuming from cache: {}", ldap_cache_path.display());
-            let cache = BincodeFileIterator::from_path(ldap_cache_path)?;
+            let cache = DiskStorageReader::from_path(ldap_cache_path)?;
             rusthound_ce::prepare_results_from_source(cache, &common_args, None).await?
         }
         false => {
@@ -68,7 +68,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 )?;
                 info!("Using cache for LDAP search: {}", ldap_cache_path.display());
 
-                let mut cache_writer = BincodeDiskStorage::new_with_capacity(
+                let mut cache_writer = DiskStorage::new_with_capacity(
                     ldap_cache_path,
                     common_args.cache_buffer_size,
                 )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     .await?;
 
     // Add all in json files
-    match rusthound_ce::export_results(&common_args, results) {
+    match rusthound_ce::make_result(&common_args, results) {
         Ok(_) => trace!("Making json/zip files finished!"),
         Err(err) => error!("Error. Reason: {err}"),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,48 +1,28 @@
-pub mod modules;
-pub mod enums;
-pub mod json;
-
-pub mod args;
-pub mod objects;
-pub mod utils;
 pub mod banner;
-pub mod ldap;
+pub mod modules;
 
-use log::{info,trace,error};
 use env_logger::Builder;
-use std::collections::HashMap;
+use log::{error, info, trace};
+
+use rusthound_ce::{
+    args, ldap, objects,
+    storage::{BincodeDiskStorage, BincodeFileIterator},
+    utils,
+};
+
 use std::error::Error;
 
-#[cfg(not(feature = "noargs"))]
-use args::{Options,extract_args};
 #[cfg(feature = "noargs")]
 use args::auto_args;
+#[cfg(not(feature = "noargs"))]
+use args::{extract_args, Options};
 
-use banner::{print_banner,print_end_banner};
+use banner::{print_banner, print_end_banner};
 use ldap::ldap_search;
 use modules::run_modules;
-use json::{
-    parser::parse_result_type,
-    checker::check_all_result,
-    maker::make_result,
-};
-use objects::{
-    user::User,
-    computer::Computer,
-    group::Group,
-    ou::Ou,
-    container::Container,
-    gpo::Gpo,
-    domain::Domain,
-    fsp::Fsp,
-    trust::Trust,
-    ntauthstore::NtAuthStore,
-    aiaca::AIACA,
-    rootca::RootCA,
-    enterpriseca::EnterpriseCA,
-    certtemplate::CertTemplate,
-    inssuancepolicie::IssuancePolicie,
-};
+
+const CACHE_DIR: &str = ".rusthound-cache";
+const CACHE_FILE: &str = "ldap.bin";
 
 /// Main of RustHound
 #[tokio::main]
@@ -66,121 +46,87 @@ async fn main() -> Result<(), Box<dyn Error>> {
     info!("Verbosity level: {:?}", common_args.verbose);
     info!("Collection method: {:?}", common_args.collection_method);
 
-    // LDAP request to get all informations in result
-    let result = ldap_search(
-        common_args.ldaps,
-        common_args.ip.as_deref(),
-        &common_args.port,
-        &common_args.domain,
-        &common_args.ldapfqdn,
-        common_args.username.as_deref(),
-        common_args.password.as_deref(),
-        common_args.kerberos,
-        &common_args.ldap_filter
-    ).await?;
+    let mut results = match common_args.resume {
+        true => {
+            let ldap_cache_path = std::path::PathBuf::from(CACHE_DIR)
+                .join(&common_args.domain)
+                .join(CACHE_FILE);
+            info!("Resuming from cache: {}", ldap_cache_path.display());
+            let cache = BincodeFileIterator::from_path(ldap_cache_path)?;
+            rusthound_ce::prepare_results_from_source(cache, &common_args, None).await?
+        }
+        false => {
+            if common_args.cache {
+                // store ldap results in cache
+                let ldap_cache_path = std::path::PathBuf::from(CACHE_DIR)
+                    .join(&common_args.domain)
+                    .join(CACHE_FILE);
+                std::fs::create_dir_all(
+                    ldap_cache_path
+                        .parent()
+                        .expect("Unable to get parent directory for cache path"), // shouldn't happen
+                )?;
+                info!("Using cache for LDAP search: {}", ldap_cache_path.display());
 
-    // Vector for content all
-    let mut vec_users:              Vec<User>            = Vec::new();
-    let mut vec_groups:             Vec<Group>           = Vec::new();
-    let mut vec_computers:          Vec<Computer>        = Vec::new();
-    let mut vec_ous:                Vec<Ou>              = Vec::new();
-    let mut vec_domains:            Vec<Domain>          = Vec::new();
-    let mut vec_gpos:               Vec<Gpo>             = Vec::new();
-    let mut vec_fsps:               Vec<Fsp>             = Vec::new();
-    let mut vec_containers:         Vec<Container>       = Vec::new();
-    let mut vec_trusts:             Vec<Trust>           = Vec::new();
-    let mut vec_ntauthstores:       Vec<NtAuthStore>     = Vec::new();
-    let mut vec_aiacas:             Vec<AIACA>           = Vec::new();
-    let mut vec_rootcas:            Vec<RootCA>          = Vec::new();
-    let mut vec_enterprisecas:      Vec<EnterpriseCA>    = Vec::new();
-    let mut vec_certtemplates:      Vec<CertTemplate>    = Vec::new();
-    let mut vec_issuancepolicies:   Vec<IssuancePolicie> = Vec::new();
+                let mut cache_writer = BincodeDiskStorage::new_with_capacity(
+                    ldap_cache_path,
+                    common_args.cache_buffer_size,
+                )?;
 
-    // Hashmap to link DN to SID
-    let mut dn_sid: HashMap<String, String> = HashMap::new();
-    // Hashmap to link DN to Type
-    let mut sid_type: HashMap<String, String> = HashMap::new();
-    // Hashmap to link FQDN to SID
-    let mut fqdn_sid: HashMap<String, String> = HashMap::new();
-    // Hashmap to link fqdn to an ip address
-    let mut fqdn_ip: HashMap<String, String> = HashMap::new();
+                let total_cached = ldap_search(
+                    common_args.ldaps,
+                    common_args.ip.as_deref(),
+                    common_args.port,
+                    &common_args.domain,
+                    &common_args.ldapfqdn,
+                    common_args.username.as_deref(),
+                    common_args.password.as_deref(),
+                    common_args.kerberos,
+                    &common_args.ldap_filter,
+                    &mut cache_writer,
+                )
+                .await?;
 
-    // Analyze object by object 
-    // Get type and parse it to get values
-    parse_result_type(
-        &common_args,
-        result,
-        &mut vec_users,
-        &mut vec_groups,
-        &mut vec_computers,
-        &mut vec_ous,
-        &mut vec_domains,
-        &mut vec_gpos,
-        &mut vec_fsps,
-        &mut vec_containers,
-        &mut vec_trusts,
-        &mut vec_ntauthstores,
-        &mut vec_aiacas,
-        &mut vec_rootcas,
-        &mut vec_enterprisecas,
-        &mut vec_certtemplates,
-        &mut vec_issuancepolicies,
-        &mut dn_sid,
-        &mut sid_type,
-        &mut fqdn_sid,
-        &mut fqdn_ip,
-    )?;
-    
-    // Functions to replace and add missing values
-    check_all_result(
-        &common_args,
-        &mut vec_users,
-        &mut vec_groups,
-        &mut vec_computers,
-        &mut vec_ous,
-        &mut vec_domains,
-        &mut vec_gpos,
-        &mut vec_fsps,
-        &mut vec_containers,
-        &mut vec_trusts,
-        &mut vec_ntauthstores,
-        &mut vec_aiacas,
-        &mut vec_rootcas,
-        &mut vec_enterprisecas,
-        &mut vec_certtemplates,
-        &mut vec_issuancepolicies,
-        &mut dn_sid,
-        &mut sid_type,
-        &mut fqdn_sid,
-        &mut fqdn_ip,
-    )?;
+                rusthound_ce::prepare_results_from_source(
+                    cache_writer.into_reader()?,
+                    &common_args,
+                    Some(total_cached),
+                )
+                .await?
+            } else {
+                // store ldap results in memory
+                let mut ldap_results = Vec::new();
+                let total = rusthound_ce::ldap::ldap_search(
+                    common_args.ldaps,
+                    common_args.ip.as_deref(),
+                    common_args.port,
+                    &common_args.domain,
+                    &common_args.ldapfqdn,
+                    common_args.username.as_deref(),
+                    common_args.password.as_deref(),
+                    common_args.kerberos,
+                    &common_args.ldap_filter,
+                    &mut ldap_results,
+                )
+                .await?;
+                rusthound_ce::prepare_results_from_source(ldap_results, &common_args, Some(total))
+                    .await?
+            }
+        }
+    };
 
     // Running modules
     run_modules(
         &common_args,
-        &mut fqdn_ip,
-        &mut vec_computers,
-    ).await?;
+        &mut results.mappings.fqdn_ip,
+        &mut results.computers,
+    )
+    .await?;
 
     // Add all in json files
-    match make_result(
-        &common_args,
-        vec_users,
-        vec_groups,
-        vec_computers,
-        vec_ous,
-        vec_domains,
-        vec_gpos,
-        vec_containers,
-        vec_ntauthstores,
-        vec_aiacas,
-        vec_rootcas,
-        vec_enterprisecas,
-        vec_certtemplates,
-        vec_issuancepolicies,
-    ) {
-        Ok(_res) => trace!("Making json/zip files finished!"),
-        Err(err) => error!("Error. Reason: {err}")
+    match rusthound_ce::export_results(&common_args, results) {
+        Ok(_) => trace!("Making json/zip files finished!"),
+        Err(err) => error!("Error. Reason: {err}"),
     }
 
     // End banner

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -3,13 +3,13 @@
 //! Example in rust:
 //!
 //! ```rust
-//! # use rusthound::objects::user::User;
-//! # use rusthound::objects::group::Group;
-//! # use rusthound::objects::computer::Computer;
-//! # use rusthound::objects::ou::Ou;
-//! # use rusthound::objects::gpo::Gpo;
-//! # use rusthound::objects::domain::Domain;
-//! # use rusthound::objects::container::Container;
+//! # use rusthound_ce::objects::user::User;
+//! # use rusthound_ce::objects::group::Group;
+//! # use rusthound_ce::objects::computer::Computer;
+//! # use rusthound_ce::objects::ou::Ou;
+//! # use rusthound_ce::objects::gpo::Gpo;
+//! # use rusthound_ce::objects::domain::Domain;
+//! # use rusthound_ce::objects::container::Container;
 //!
 //! let user = User::new();
 //! let group = Group::new();

--- a/src/storage/buffer.rs
+++ b/src/storage/buffer.rs
@@ -1,0 +1,151 @@
+use std::error::Error;
+use std::fs::OpenOptions;
+use std::io::{BufReader, BufWriter, Seek, Write};
+use std::path::Path;
+
+pub use super::iter::BincodeIterator;
+
+const DEFAULT_BUFFER_SIZE: usize = 1000;
+
+pub trait Storage<T>
+where
+    Self: Sized,
+{
+    /// Returns a mutable reference to the internal buffer
+    fn buffer_mut(&mut self) -> &mut Vec<T>;
+
+    /// Flush the buffer to disk
+    fn flush(&mut self) -> Result<(), Box<dyn Error>>;
+
+    /// Add an item to the buffer,
+    /// Default implemetation flushes to disk if it reaches capacity
+    fn add(&mut self, item: T) -> Result<(), Box<dyn Error>> {
+        self.buffer_mut().push(item);
+
+        if self.buffer_mut().len() >= self.buffer_mut().capacity() {
+            self.flush()?;
+        }
+        Ok(())
+    }
+
+    /// Flush the buffer to disk and consume `self`
+    fn finish(mut self) -> Result<(), Box<dyn Error>> {
+        self.flush()
+    }
+}
+
+impl<T> Storage<T> for Vec<T> {
+    fn buffer_mut(&mut self) -> &mut Vec<T> {
+        self
+    }
+
+    // no need to check capacity
+    fn add(&mut self, item: T) -> Result<(), Box<dyn Error>> {
+        self.push(item);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+}
+
+pub struct BincodeObjectBuffer<T> {
+    /// `BufWriter` to a file handle that is opened for reading and writing.
+    writer: BufWriter<RWHandle>,
+
+    /// Buffer for storing objects to be written to disk
+    buffer: Vec<T>,
+
+    /// Intermediate buffer for encoding objects to bincode before writing to disk
+    encode_buffer: Vec<u8>,
+}
+
+impl<T> BincodeObjectBuffer<T> {
+    pub fn new(file_path: impl AsRef<Path>) -> Result<Self, Box<dyn Error>> {
+        Ok(BincodeObjectBuffer {
+            writer: BufWriter::new(RWHandle::open(file_path)?),
+            buffer: Vec::with_capacity(DEFAULT_BUFFER_SIZE),
+            encode_buffer: Vec::new(),
+        })
+    }
+
+    pub fn new_with_capacity(
+        file_path: impl AsRef<Path>,
+        capacity: usize,
+    ) -> Result<Self, Box<dyn Error>> {
+        Ok(BincodeObjectBuffer {
+            writer: BufWriter::new(RWHandle::open(file_path)?),
+            buffer: Vec::with_capacity(capacity),
+            encode_buffer: Vec::new(),
+        })
+    }
+}
+
+impl<T: bincode::Decode<()>> BincodeObjectBuffer<T> {
+    pub fn into_reader(
+        self,
+    ) -> Result<BincodeIterator<T, BufReader<std::fs::File>>, Box<dyn Error>> {
+        let mut inner = self.writer.into_inner()?;
+        inner.0.seek(std::io::SeekFrom::Start(0))?;
+        Ok(BincodeIterator::from_file(inner.0))
+    }
+}
+
+impl<T> Storage<T> for BincodeObjectBuffer<T>
+where
+    T: bincode::Encode,
+{
+    #[inline]
+    fn buffer_mut(&mut self) -> &mut Vec<T> {
+        &mut self.buffer
+    }
+
+    fn flush(&mut self) -> Result<(), Box<dyn Error>> {
+        for item in self.buffer.drain(..) {
+            self.encode_buffer.clear();
+            bincode::encode_into_std_write(
+                &item,
+                &mut self.encode_buffer,
+                bincode::config::standard(),
+            )?;
+
+            let len = self.encode_buffer.len() as u32;
+            self.writer.write_all(&len.to_le_bytes())?;
+            self.writer.write_all(&self.encode_buffer)?;
+        }
+
+        self.writer.flush()?;
+
+        Ok(())
+    }
+}
+
+/// Wrapper around a file handle. Used to indicate that the file is opened for reading and writing.
+///
+/// Will truncate the file if it already exists.
+#[derive(Debug)]
+struct RWHandle(std::fs::File);
+
+impl RWHandle {
+    pub fn open(file_path: impl AsRef<Path>) -> Result<Self, Box<dyn Error>> {
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .read(true) // read so we can read back the file later
+            .truncate(true)
+            .open(file_path)?;
+
+        Ok(RWHandle(file))
+    }
+}
+
+impl std::io::Write for RWHandle {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.flush()
+    }
+}

--- a/src/storage/buffer.rs
+++ b/src/storage/buffer.rs
@@ -104,7 +104,7 @@ where
     fn flush(&mut self) -> Result<(), Box<dyn Error>> {
         for item in self.buffer.drain(..) {
             self.encode_buffer.clear();
-            bincode::encode_into_std_write(
+            bincode::encode_into_slice(
                 &item,
                 &mut self.encode_buffer,
                 bincode::config::standard(),

--- a/src/storage/buffer.rs
+++ b/src/storage/buffer.rs
@@ -18,7 +18,7 @@ where
     fn flush(&mut self) -> Result<(), Box<dyn Error>>;
 
     /// Add an item to the buffer,
-    /// Default implemetation flushes to disk if it reaches capacity
+    /// Default implemetation calls [`Storage::flush`] if it reaches capacity
     fn add(&mut self, item: T) -> Result<(), Box<dyn Error>> {
         self.buffer_mut().push(item);
 
@@ -28,7 +28,7 @@ where
         Ok(())
     }
 
-    /// Flush the buffer to disk and consume `self`
+    /// Flush the buffer and consume `self`
     fn finish(mut self) -> Result<(), Box<dyn Error>> {
         self.flush()
     }

--- a/src/storage/iter.rs
+++ b/src/storage/iter.rs
@@ -1,0 +1,90 @@
+use std::error::Error;
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::marker::PhantomData;
+
+pub type BincodeFileIterator<T> = BincodeIterator<T, BufReader<File>>;
+
+/// Lazy iterator for bincode-encoded, length-prefixed data
+pub struct BincodeIterator<T, R: Read> {
+    reader: R,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> BincodeIterator<T, BufReader<File>>
+where
+    T: bincode::Decode<()>,
+{
+    /// Create a new iterator from a file path
+    pub fn from_path(file_path: impl AsRef<std::path::Path>) -> std::io::Result<Self> {
+        let file = File::open(file_path)?;
+        let reader = BufReader::new(file);
+        Ok(Self {
+            reader,
+            _phantom: PhantomData,
+        })
+    }
+
+    pub fn from_file(file: std::fs::File) -> Self {
+        Self {
+            reader: BufReader::new(file),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, R: Read> BincodeIterator<T, R>
+where
+    T: bincode::Decode<()>,
+{
+    /// Create a new iterator from any reader
+    pub fn new(reader: R) -> Self {
+        Self {
+            reader,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, R: Read> Iterator for BincodeIterator<T, R>
+where
+    T: bincode::Decode<()>,
+{
+    type Item = Result<T, Box<dyn Error>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Try to read length prefix
+        let mut len_bytes = [0u8; 4];
+        match self.reader.read_exact(&mut len_bytes) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                // Clean EOF - no more records
+                return None;
+            }
+            Err(e) => return Some(Err(e.into())),
+        }
+
+        let len = u32::from_le_bytes(len_bytes) as usize;
+
+        // Validate length to prevent excessive allocation
+        // if len > 100_000_000 {
+        //     // 100MB limit, adjust as needed
+        //     return Some(Err(format!(
+        //         "Item length {len} exceeds maximum allowed size"
+        //     )
+        //     .into()));
+        // }
+
+        // Read the exact amount of data for this item
+        let mut data = vec![0u8; len];
+        if let Err(e) = self.reader.read_exact(&mut data) {
+            return Some(Err(format!("Failed to read {len} bytes: {e}").into()));
+        }
+
+        // Decode the item
+        match bincode::decode_from_slice::<T, _>(&data, bincode::config::standard()) {
+            Ok((item, _)) => Some(Ok(item)),
+            Err(e) => Some(Err(format!("Failed to decode item: {e:?}").into())),
+        }
+    }
+}

--- a/src/storage/iter.rs
+++ b/src/storage/iter.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::{BufReader, Read};
 use std::marker::PhantomData;
 
-pub type BincodeFileIterator<T> = BincodeIterator<T, BufReader<File>>;
+pub type DiskStorageReader<T> = BincodeIterator<T, BufReader<File>>;
 
 /// Lazy iterator for bincode-encoded, length-prefixed data
 pub struct BincodeIterator<T, R: Read> {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,0 +1,42 @@
+pub mod buffer;
+pub mod iter;
+use std::error::Error;
+
+pub use iter::BincodeIterator;
+
+pub use buffer::{BincodeObjectBuffer, Storage};
+
+use crate::ldap::LdapSearchEntry;
+pub use iter::BincodeFileIterator;
+
+pub type BincodeDiskStorage = BincodeObjectBuffer<LdapSearchEntry>;
+
+/// Used to iterate over LDAP search entries.
+///
+// trait is required because BincodeFileIterator will return a Result(LdapSearchEntry, Box<dyn Error>)
+// without this trait the caller has to convert like `self.into_iter().map(Ok)`
+pub trait EntrySource {
+    type Iter: Iterator<Item = Result<LdapSearchEntry, Box<dyn Error>>>;
+    fn into_entry_iter(self) -> Self::Iter;
+}
+
+// For reading from cache
+impl EntrySource for BincodeFileIterator<LdapSearchEntry> {
+    type Iter = Self;
+
+    fn into_entry_iter(self) -> Self::Iter {
+        self
+    }
+}
+
+// For reading from memory
+impl EntrySource for Vec<LdapSearchEntry> {
+    type Iter = std::iter::Map<
+        std::vec::IntoIter<LdapSearchEntry>,
+        fn(LdapSearchEntry) -> Result<LdapSearchEntry, Box<dyn Error>>,
+    >;
+
+    fn into_entry_iter(self) -> Self::Iter {
+        self.into_iter().map(Ok)
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2,14 +2,12 @@ pub mod buffer;
 pub mod iter;
 use std::error::Error;
 
-pub use iter::BincodeIterator;
-
 pub use buffer::{BincodeObjectBuffer, Storage};
 
 use crate::ldap::LdapSearchEntry;
-pub use iter::BincodeFileIterator;
+pub use iter::DiskStorageReader;
 
-pub type BincodeDiskStorage = BincodeObjectBuffer<LdapSearchEntry>;
+pub type DiskStorage = BincodeObjectBuffer<LdapSearchEntry>;
 
 /// Used to iterate over LDAP search entries.
 ///
@@ -21,7 +19,7 @@ pub trait EntrySource {
 }
 
 // For reading from cache
-impl EntrySource for BincodeFileIterator<LdapSearchEntry> {
+impl EntrySource for DiskStorageReader<LdapSearchEntry> {
     type Iter = Self;
 
     fn into_entry_iter(self) -> Self::Iter {


### PR DESCRIPTION
Adds feature #7

## Changes
- New type `LdapSearchResult` since `ldap3::SearchResult` doesn't implement Serialize
- Two new traits
  - `EntrySource`: Used to read `LdapSearchResults`
    - Implemented for `DiskStorageReader<LdapSearchEntry>` and `Vec<LdapSearchEntry>`
  - `Storage`: Used to store `LdapSearchResults`
    - Implemented for `DiskStorage<T>` and `Vec<T>`
 - Updated the api for a few functions
   - `ldap::ldap_search` now requires an `&mut Storage`
   -  Updated `json::maker::make_result` now accepts `ADResults` in place of all the previous container arguments
   - `check_all_result` now takes an immutable reference for `HashMap` arguments
   - `enums::ldaptype::get_type` now takes a reference to `SearchEntry`
   - Changed `port` argument to be `Option<u16>` for `prepare_ldap_url`, `ldap_constructor` and `ldap_search`
- Dependency on `bincode` for encoding/decoding 
- Adds `--cache`, `--cache-buffer`, and `--resume` CLI flags
- Fixed and ignored some broken doc tests
- Reorganized imports in `main.rs` to improve compilation
  - Modules that were already being exported from the library were being redeclared for compilation in `main.rs`

## Details
Adds the ability to store/load ldap results from disk. This is controlled by 2 CLI flags, `--cache` and `--cache-buffer`. When the `--cache` flag is passed, instead of storing all ldap search results in memory, they'll be added to a buffer that gets written to disk once the number of entries reaches capacity / `--cache-buffer`  (default is 1000). 

When preparing results, each entry will be read from disk and processed 1-by-1.

Also adds a `--resume` flag which will skip the ldap search and begin preparing the results from disk.

I chose use [bincode](https://docs.rs/bincode/latest/bincode) to encode/decode the entries since it's much faster than parsing json

## Profiling/Testing
Only had the chance to check against a really small domain

22 users, 60 groups, 4 computers, 1 ous, 3 domains, 2 gpos, 78 containers

### Decoding (3683 LDAP objects)

JSONL: `3885ms`
bincode: `99ms`

### DHAT (Full program execution)

| Metric | In Memory | On Disk | Difference | % Change |
|--------|-----------|------------|------------|----------|
| **Total Bytes** | 150,562,759 bytes (143.6 MB) | 152,756,053 bytes (145.7 MB) | +2,193,294 bytes (+2.1 MB) | +1.5% |
| **Total Blocks** | 1,664,135 | 1,803,715 | +139,580 | +8.4% |
| **Peak Bytes (t-gmax)** | 19,348,560 bytes (18.5 MB) | 5,704,238 bytes (5.4 MB) | -13,644,322 bytes (-13.6 MB) | -70.5% |
| **Peak Blocks (t-gmax)** | 274,226 | 83,068 | -191,158 | -69.7% |
