### PR TITLE
Ignore when Domain Object Identifier is null

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -148,7 +148,10 @@ pub fn parse_result_type_from_source(
                 let domain_sid_from_domain =
                     domain_object.parse(entry, domain, dn_sid, sid_type)?;
                 domain_sid = domain_sid_from_domain;
-                results.domains.push(domain_object);
+                // Only add domains with valid ObjectIdentifier (excludes DomainDnsZones, ForestDnsZones, etc.)
+                if !domain_object.object_identifier().is_empty() {
+                    results.domains.push(domain_object);
+                }
             }
             Type::Gpo => {
                 let mut gpo = Gpo::new();

--- a/src/json/parser/mod.rs
+++ b/src/json/parser/mod.rs
@@ -127,7 +127,10 @@ pub fn parse_result_type(
                     sid_type,
                 )?;
                 domain_sid = domain_sid_from_domain;
-                vec_domains.push(domain_object);
+                // Only add domains with valid ObjectIdentifier (excludes DomainDnsZones, ForestDnsZones, etc.)
+                if !domain_object.object_identifier().is_empty() {
+                    vec_domains.push(domain_object);
+                }
             }
             Type::Gpo => {
                 let mut  gpo = Gpo::new();

--- a/src/objects/domain.rs
+++ b/src/objects/domain.rs
@@ -51,6 +51,9 @@ impl Domain {
     pub fn properties_mut(&mut self) -> &mut DomainProperties {
         &mut self.properties
     }
+    pub fn object_identifier(&self) -> &String {
+        &self.object_identifier
+    }
     pub fn object_identifier_mut(&mut self) -> &mut String {
         &mut self.object_identifier
     }


### PR DESCRIPTION
This is an attempt to resolve: https://github.com/g0h4n/RustHound-CE/issues/15

It appears the domains json file is what contains the null Object Identifier.  I ran SharpHound to see how the "official" way handles this, and interestingly enough the data was just not there:

This is from Rusthound:
```
$ cat *-htb_domains.json | jq .data[].Properties.name
"RUSTYKEY.HTB"
"DOMAINDNSZONES.RUSTYKEY.HTB"
"FORESTDNSZONES.RUSTYKEY.HTB"
```
And here is SharpHound
```
$ cat 20251103174735_domains.json  | jq .data[].Properties.name
"RUSTYKEY.HTB"
```

I believe the line of code that is preventing the two zones from being collected in Sharphound is here:
https://github.com/SpecterOps/SharpHound/blob/dc420a63a55f032752ab0bc671c13b35053427eb/src/Runtime/LDAPConsumer.cs#L25-L54

I couldn't find a way to replicate this identically, so instead I added checks in the `src/api.rs` and `src/json/parser/mod.rs`, I also exposed a getter to the Domain struct for retrieving the variable.