### PR TITLE
Make computer name / ContainedBy / ADCS template resolution deterministicFix nondeterminism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crypto"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1470,6 +1495,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libz-rs-sys"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,6 +1573,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2069,6 +2112,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rc2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2216,11 +2279,13 @@ dependencies = [
  "lazy_static",
  "ldap3",
  "log",
+ "mimalloc",
  "nom",
  "obfstr",
  "once_cell",
  "picky",
  "picky-krb",
+ "rayon",
  "regex",
  "rpassword",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ regex = "1"
 once_cell = "1.19"
 bincode = "2.0.1"
 obfstr = "0.4.1"
+rayon = "1.10"
+mimalloc = "0.1"
 
 [features]
 noargs = ["winreg"] # Only available for Windows
@@ -45,7 +47,7 @@ nogssapi = ["ldap3/tls-rustls-ring", "ldap3/ntlm"] # Used for linux_musl armv7 a
 default = ["ldap3/tls-rustls-ring", "ldap3/gssapi", "ldap3/ntlm"]
 
 [profile.release]
-opt-level = "z"
+opt-level = 3
 lto = true
 strip = true
 codegen-units = 1

--- a/src/api.rs
+++ b/src/api.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, error::Error};
 
 use indicatif::ProgressBar;
 use ldap3::SearchEntry;
+use rayon::prelude::*;
 
 use crate::{
     args::Options, banner::progress_bar, enums::{PARSER_MOD_RE1, PARSER_MOD_RE2, Type, get_type}, json::checker::check_all_result, 
@@ -23,8 +24,9 @@ use crate::{
         trust::Trust,
         user::User,
         schema::Schema,
-    }, 
-    storage::EntrySource
+    },
+    ldap::LdapSearchEntry,
+    storage::{DiskStorageReader, EntrySource},
 };
 
 #[derive(Default)]
@@ -73,8 +75,26 @@ pub async fn prepare_results_from_source<S: EntrySource>(
     total_objects: Option<usize>,
 ) -> Result<ADResults, Box<dyn std::error::Error>> {
     let mut ad_results = parse_result_type_from_source(options, source, total_objects)?;
+    run_checker(options, &mut ad_results)?;
+    Ok(ad_results)
+}
 
-    // Functions to replace and add missing values
+/// Like [`prepare_results_from_source`], but reads directly from a disk cache
+/// (`--cache` / `--resume`). The heavy bincode decode of each record is done on
+/// worker threads instead of the single reader thread, which is the difference
+/// between a mostly-idle CPU and a saturated one on large caches.
+pub async fn prepare_results_from_disk(
+    reader: DiskStorageReader<LdapSearchEntry>,
+    options: &Options,
+    total_objects: Option<usize>,
+) -> Result<ADResults, Box<dyn std::error::Error>> {
+    let mut ad_results = parse_result_type_from_disk(options, reader, total_objects)?;
+    run_checker(options, &mut ad_results)?;
+    Ok(ad_results)
+}
+
+/// Post-parse pass: replace and add missing values.
+fn run_checker(options: &Options, ad_results: &mut ADResults) -> Result<(), Box<dyn std::error::Error>> {
     check_all_result(
         options,
         &mut ad_results.users,
@@ -96,13 +116,244 @@ pub async fn prepare_results_from_source<S: EntrySource>(
         &ad_results.mappings.sid_type,
         &ad_results.mappings.fqdn_sid,
         &ad_results.mappings.fqdn_ip,
-    )?;
+    )
+}
 
-    Ok(ad_results)
+/// Number of bulk entries buffered before being parsed as one parallel batch.
+///
+/// The batch is split across all CPU cores by rayon, then merged sequentially.
+/// A larger value amortizes scheduling overhead; keeping it bounded caps the
+/// extra memory to one batch of `SearchEntry`s regardless of domain size.
+const PARSE_BATCH: usize = 16_384;
+
+/// Map contributions produced by parsing a single object.
+///
+/// Each `parse()` only ever *inserts* the object's own DN→SID / SID→Type
+/// (and, for computers, FQDN→SID / FQDN→IP) entries — it never reads the maps.
+/// That makes bulk parsing data-parallel: every thread fills its own
+/// `LocalMaps`, which are merged into the global maps afterwards.
+#[derive(Default)]
+struct LocalMaps {
+    dn_sid: HashMap<String, String>,
+    sid_type: HashMap<String, String>,
+    fqdn_sid: HashMap<String, String>,
+    fqdn_ip: HashMap<String, String>,
+}
+
+/// A parsed object, tagged by collection so the merge step can route it into
+/// the right vector. `Domain` and `Schema` are parsed sequentially (they must
+/// run before the bulk), so they never appear here.
+enum Parsed {
+    User(Box<User>),
+    Group(Box<Group>),
+    Computer(Box<Computer>),
+    Ou(Box<Ou>),
+    Gpo(Box<Gpo>),
+    Fsp(Box<Fsp>),
+    Container(Box<Container>),
+    Trust(Box<Trust>),
+    NtAuthStore(Box<NtAuthStore>),
+    AIACA(Box<AIACA>),
+    RootCA(Box<RootCA>),
+    EnterpriseCA(Box<EnterpriseCA>),
+    CertTemplate(Box<CertTemplate>),
+    IssuancePolicie(Box<IssuancePolicie>),
+    /// Filtered-out container, unknown/other object — nothing to collect.
+    Skip,
+}
+
+/// Parse one bulk entry. Runs on a rayon worker thread, so it takes the shared
+/// `schema_guid_map`/`domain_sid` by read-only reference and returns its own
+/// local map contributions.
+fn parse_one(
+    entry: SearchEntry,
+    domain: &str,
+    domain_sid: &str,
+    schema_guid_map: &HashMap<String, String>,
+) -> Result<(Parsed, LocalMaps), Box<dyn Error>> {
+    let mut m = LocalMaps::default();
+    let atype = get_type(&entry).unwrap_or(Type::Unknown);
+
+    let parsed = match atype {
+        Type::User => {
+            let mut user = User::new();
+            user.parse(entry, domain, &mut m.dn_sid, &mut m.sid_type, domain_sid, schema_guid_map)?;
+            Parsed::User(Box::new(user))
+        }
+        Type::Group => {
+            let mut group = Group::new();
+            group.parse(entry, domain, &mut m.dn_sid, &mut m.sid_type, domain_sid, schema_guid_map)?;
+            Parsed::Group(Box::new(group))
+        }
+        Type::Computer => {
+            let mut computer = Computer::new();
+            computer.parse(
+                entry, domain,
+                &mut m.dn_sid, &mut m.sid_type, &mut m.fqdn_sid, &mut m.fqdn_ip,
+                domain_sid, schema_guid_map,
+            )?;
+            Parsed::Computer(Box::new(computer))
+        }
+        Type::Ou => {
+            let mut ou = Ou::new();
+            ou.parse(entry, domain, &mut m.dn_sid, &mut m.sid_type, domain_sid, schema_guid_map)?;
+            Parsed::Ou(Box::new(ou))
+        }
+        Type::Gpo => {
+            let mut gpo = Gpo::new();
+            gpo.parse(entry, domain, &mut m.dn_sid, &mut m.sid_type, domain_sid, schema_guid_map)?;
+            Parsed::Gpo(Box::new(gpo))
+        }
+        Type::ForeignSecurityPrincipal => {
+            let mut security_principal = Fsp::new();
+            security_principal.parse(entry, domain, &mut m.dn_sid, &mut m.sid_type, domain_sid)?;
+            Parsed::Fsp(Box::new(security_principal))
+        }
+        Type::Container => {
+            if PARSER_MOD_RE1.is_match(&entry.dn.to_uppercase())
+                || PARSER_MOD_RE2.is_match(&entry.dn.to_uppercase())
+            {
+                Parsed::Skip
+            } else {
+                let mut container = Container::new();
+                container.parse(entry, domain, &mut m.dn_sid, &mut m.sid_type, domain_sid, schema_guid_map)?;
+                Parsed::Container(Box::new(container))
+            }
+        }
+        Type::Trust => {
+            let mut trust = Trust::new();
+            trust.parse(entry, domain)?;
+            Parsed::Trust(Box::new(trust))
+        }
+        Type::NtAutStore => {
+            let mut nt_auth_store = NtAuthStore::new();
+            nt_auth_store.parse(entry, domain, &mut m.dn_sid, &mut m.sid_type, domain_sid, schema_guid_map)?;
+            Parsed::NtAuthStore(Box::new(nt_auth_store))
+        }
+        Type::AIACA => {
+            let mut aiaca = AIACA::new();
+            aiaca.parse(entry, domain, &mut m.dn_sid, &mut m.sid_type, domain_sid, schema_guid_map)?;
+            Parsed::AIACA(Box::new(aiaca))
+        }
+        Type::RootCA => {
+            let mut root_ca = RootCA::new();
+            root_ca.parse(entry, domain, &mut m.dn_sid, &mut m.sid_type, domain_sid, schema_guid_map)?;
+            Parsed::RootCA(Box::new(root_ca))
+        }
+        Type::EnterpriseCA => {
+            let mut enterprise_ca = EnterpriseCA::new();
+            enterprise_ca.parse(entry, domain, &mut m.dn_sid, &mut m.sid_type, domain_sid, schema_guid_map)?;
+            Parsed::EnterpriseCA(Box::new(enterprise_ca))
+        }
+        Type::CertTemplate => {
+            let mut cert_template = CertTemplate::new();
+            cert_template.parse(entry, domain, &mut m.dn_sid, &mut m.sid_type, domain_sid, schema_guid_map)?;
+            Parsed::CertTemplate(Box::new(cert_template))
+        }
+        Type::IssuancePolicie => {
+            let mut issuance_policie = IssuancePolicie::new();
+            issuance_policie.parse(entry, domain, &mut m.dn_sid, &mut m.sid_type, domain_sid, schema_guid_map)?;
+            Parsed::IssuancePolicie(Box::new(issuance_policie))
+        }
+        // Handled sequentially before the bulk; should not reach here.
+        Type::Domain | Type::Schema => Parsed::Skip,
+        Type::Unknown => {
+            let _unknown = parse_unknown(entry, domain);
+            Parsed::Skip
+        }
+    };
+
+    Ok((parsed, m))
+}
+
+/// Parse a buffered batch of bulk entries in parallel and merge the results
+/// (objects + map contributions) into `results`, preserving input order.
+#[allow(clippy::too_many_arguments)]
+fn parse_batch(
+    buffer: &mut Vec<SearchEntry>,
+    results: &mut ADResults,
+    domain: &str,
+    domain_sid: &str,
+    count: &mut usize,
+    total: Option<usize>,
+    pb: &ProgressBar,
+) -> Result<(), Box<dyn Error>> {
+    if buffer.is_empty() {
+        return Ok(());
+    }
+
+    let entries = std::mem::take(buffer);
+
+    // Serialize across all CPU cores. Errors are stringified inside the worker
+    // (Box<dyn Error> isn't Send) so fail-fast semantics are preserved.
+    let parsed: Vec<Result<(Parsed, LocalMaps), String>> = {
+        let schema_guid_map = &results.mappings.schema_guid_map;
+        entries
+            .into_par_iter()
+            .map(|entry| parse_one(entry, domain, domain_sid, schema_guid_map).map_err(|e| e.to_string()))
+            .collect()
+    };
+
+    // Merge sequentially, in input order, so output ordering matches the
+    // single-threaded collector exactly.
+    for item in parsed {
+        let (obj, maps) = item.map_err(|e| -> Box<dyn Error> { e.into() })?;
+
+        results.mappings.dn_sid.extend(maps.dn_sid);
+        results.mappings.sid_type.extend(maps.sid_type);
+        results.mappings.fqdn_sid.extend(maps.fqdn_sid);
+        results.mappings.fqdn_ip.extend(maps.fqdn_ip);
+
+        match obj {
+            Parsed::User(o) => results.users.push(*o),
+            Parsed::Group(o) => results.groups.push(*o),
+            Parsed::Computer(o) => results.computers.push(*o),
+            Parsed::Ou(o) => results.ous.push(*o),
+            Parsed::Gpo(o) => results.gpos.push(*o),
+            Parsed::Fsp(o) => results.fsps.push(*o),
+            Parsed::Container(o) => results.containers.push(*o),
+            Parsed::Trust(o) => results.trusts.push(*o),
+            Parsed::NtAuthStore(o) => results.ntauthstores.push(*o),
+            Parsed::AIACA(o) => results.aiacas.push(*o),
+            Parsed::RootCA(o) => results.rootcas.push(*o),
+            Parsed::EnterpriseCA(o) => results.enterprisecas.push(*o),
+            Parsed::CertTemplate(o) => results.certtemplates.push(*o),
+            Parsed::IssuancePolicie(o) => results.issuancepolicies.push(*o),
+            Parsed::Skip => {}
+        }
+
+        update_progress(count, total, pb)?;
+    }
+
+    Ok(())
+}
+
+/// Advance the parsing progress bar.
+fn update_progress(count: &mut usize, total: Option<usize>, pb: &ProgressBar) -> Result<(), Box<dyn Error>> {
+    if let Some(total) = total {
+        *count += 1;
+        // Percentage (%) = 100 x partial value / total value
+        let percentage = 100 * *count / total;
+        progress_bar(
+            pb.to_owned(),
+            "Parsing LDAP objects".to_string(),
+            percentage.try_into()?,
+            "%".to_string(),
+        );
+    }
+    Ok(())
 }
 
 // for `total_objects`, the total number of objects may not be known if the ldap query was never run
 // (e.g run was resumed from cached results)
+//
+// Parsing strategy:
+//   * Schema and Domain objects are parsed sequentially as they stream in. The
+//     collector guarantees they come first (see the naming-context ordering in
+//     `ldap.rs`), and the rest of the parsing reads `schema_guid_map` /
+//     `domain_sid` read-only, so they must be complete beforehand.
+//   * Every other object is buffered and parsed in parallel batches across all
+//     CPU cores, which is the hot path on large domains.
 pub fn parse_result_type_from_source(
     common_args: &Options,
     source: impl EntrySource,
@@ -114,234 +365,163 @@ pub fn parse_result_type_from_source(
 
     // Needed for progress bar stats
     let pb = ProgressBar::new(1);
-    let mut count = 0;
+    let mut count = 0usize;
     let total = total_objects;
     let mut domain_sid: String = "DOMAIN_SID".to_owned();
 
     log::info!("Starting the LDAP objects parsing...");
 
-    let dn_sid = &mut results.mappings.dn_sid;
-    let sid_type = &mut results.mappings.sid_type;
-    let fqdn_sid = &mut results.mappings.fqdn_sid;
-    let fqdn_ip = &mut results.mappings.fqdn_ip;
+    let mut buffer: Vec<SearchEntry> = Vec::with_capacity(PARSE_BATCH);
 
     for entry in source.into_entry_iter() {
         let entry: SearchEntry = entry?.into();
-        // Start parsing with Type matching
-        let atype = get_type(&entry).unwrap_or(Type::Unknown);
-        match atype {
-            Type::User => {
-                let mut user: User = User::new();
-                user.parse(
-                    entry,
-                    domain, dn_sid,
-                    sid_type,
-                    &domain_sid,
-                    &results.mappings.schema_guid_map
-                )?;
-                results.users.push(user);
-            }
-            Type::Group => {
-                let mut group = Group::new();
-                group.parse(
-                    entry,
-                    domain,
-                    dn_sid,
-                    sid_type,
-                    &domain_sid,
-                    &results.mappings.schema_guid_map
-                )?;
-                results.groups.push(group);
-            }
-            Type::Computer => {
-                let mut computer = Computer::new();
-                computer.parse(
-                    entry,
-                    domain,
-                    dn_sid,
-                    sid_type,
-                    fqdn_sid,
-                    fqdn_ip,
-                    &domain_sid,
-                    &results.mappings.schema_guid_map
-                )?;
-                results.computers.push(computer);
-            }
-            Type::Ou => {
-                let mut ou = Ou::new();
-                ou.parse(
-                    entry,
-                    domain,
-                    dn_sid,
-                    sid_type,
-                    &domain_sid,
-                    &results.mappings.schema_guid_map
-                )?;
-                results.ous.push(ou);
-            }
-            Type::Domain => {
-                let mut domain_object = Domain::new();
-                let domain_sid_from_domain =
-                    domain_object.parse(
-                        entry,
-                        domain,
-                        dn_sid,
-                        sid_type,
-                        &results.mappings.schema_guid_map
-                    )?;
-                // Update only if domain_sid is valid
-                if domain_sid_from_domain != "DOMAIN_SID" && !domain_sid_from_domain.is_empty() {
-                    domain_sid = domain_sid_from_domain;
-                }
-                if !domain_object.object_identifier().is_empty() {
-                    results.domains.push(domain_object);
-                }
-            }
-            Type::Gpo => {
-                let mut gpo = Gpo::new();
-                gpo.parse(
-                    entry,
-                    domain, dn_sid,
-                    sid_type,
-                    &domain_sid,
-                    &results.mappings.schema_guid_map
-                )?;
-                results.gpos.push(gpo);
-            }
-            Type::ForeignSecurityPrincipal => {
-                let mut security_principal = Fsp::new();
-                security_principal.parse(
-                    entry,
-                    domain,
-                    dn_sid,
-                    sid_type,
-                    &domain_sid
-                )?;
-                results.fsps.push(security_principal);
-            }
-            Type::Container => {
-                if PARSER_MOD_RE1.is_match(&entry.dn.to_uppercase())
-                    || PARSER_MOD_RE2.is_match(&entry.dn.to_uppercase())
-                {
-                    //trace!("Container not to add: {}",&cloneresult.dn.to_uppercase());
-                    continue;
-                }
-
-                //trace!("Container: {}",&entry.dn.to_uppercase());
-                let mut container = Container::new();
-                container.parse(
-                    entry,
-                    domain,
-                    dn_sid,
-                    sid_type,
-                    &domain_sid,
-                    &results.mappings.schema_guid_map
-                )?;
-                results.containers.push(container);
-            }
-            Type::Trust => {
-                let mut trust = Trust::new();
-                trust.parse(entry, domain)?;
-                results.trusts.push(trust);
-            }
-            Type::NtAutStore => {
-                let mut nt_auth_store = NtAuthStore::new();
-                nt_auth_store.parse(
-                    entry,
-                    domain,
-                    dn_sid,
-                    sid_type,
-                    &domain_sid,
-                    &results.mappings.schema_guid_map
-                )?;
-                results.ntauthstores.push(nt_auth_store);
-            }
-            Type::AIACA => {
-                let mut aiaca = AIACA::new();
-                aiaca.parse(
-                    entry,
-                    domain, dn_sid,
-                    sid_type,
-                    &domain_sid,
-                    &results.mappings.schema_guid_map
-                )?;
-                results.aiacas.push(aiaca);
-            }
-            Type::RootCA => {
-                let mut root_ca = RootCA::new();
-                root_ca.parse(
-                    entry,
-                    domain,
-                    dn_sid,
-                    sid_type,
-                    &domain_sid,
-                    &results.mappings.schema_guid_map
-                )?;
-                results.rootcas.push(root_ca);
-            }
-            Type::EnterpriseCA => {
-                let mut enterprise_ca = EnterpriseCA::new();
-                enterprise_ca.parse(
-                    entry,
-                    domain,
-                    dn_sid,
-                    sid_type,
-                    &domain_sid,
-                    &results.mappings.schema_guid_map
-                )?;
-                results.enterprisecas.push(enterprise_ca);
-            }
-            Type::CertTemplate => {
-                let mut cert_template = CertTemplate::new();
-                cert_template.parse(
-                    entry,
-                    domain,
-                    dn_sid,
-                    sid_type,
-                    &domain_sid,
-                    &results.mappings.schema_guid_map
-                )?;
-                results.certtemplates.push(cert_template);
-            }
-            Type::IssuancePolicie => {
-                let mut issuance_policie = IssuancePolicie::new();
-                issuance_policie.parse(
-                    entry,
-                    domain,
-                    dn_sid,
-                    sid_type,
-                    &domain_sid,
-                    &results.mappings.schema_guid_map
-                )?;
-                results.issuancepolicies.push(issuance_policie);
-            }
-            Type::Schema => {
-                let schema = Schema::new();
-                schema.parse(
-                    entry,
-                    &mut results.mappings.schema_guid_map,
-                )?;
-            }
-            Type::Unknown => {
-                let _unknown = parse_unknown(entry, domain);
-            }
-        }
-        // Manage progress bar
-        // Pourcentage (%) = 100 x Valeur partielle/Valeur totale
-        if let Some(total) = total {
-            count += 1;
-            let pourcentage = 100 * count / total;
-            progress_bar(
-                pb.to_owned(),
-                "Parsing LDAP objects".to_string(),
-                pourcentage.try_into()?,
-                "%".to_string(),
-            );
-        }
+        route_entry(entry, &mut results, &mut buffer, domain, &mut domain_sid, &mut count, total, &pb)?;
     }
+
+    // Parse whatever remains in the buffer.
+    parse_batch(&mut buffer, &mut results, domain, &domain_sid, &mut count, total, &pb)?;
 
     pb.finish_and_clear();
     log::info!("Parsing LDAP objects finished!");
     Ok(results)
+}
+
+/// Route a single decoded entry: schema and domain are parsed sequentially
+/// (they must complete before the bulk), everything else is buffered for
+/// parallel batch parsing.
+#[allow(clippy::too_many_arguments)]
+fn route_entry(
+    entry: SearchEntry,
+    results: &mut ADResults,
+    buffer: &mut Vec<SearchEntry>,
+    domain: &str,
+    domain_sid: &mut String,
+    count: &mut usize,
+    total: Option<usize>,
+    pb: &ProgressBar,
+) -> Result<(), Box<dyn Error>> {
+    let atype = get_type(&entry).unwrap_or(Type::Unknown);
+    match atype {
+        Type::Schema => {
+            // Sequential: builds schema_guid_map, read by every ACE parse.
+            let schema = Schema::new();
+            schema.parse(entry, &mut results.mappings.schema_guid_map)?;
+            update_progress(count, total, pb)?;
+        }
+        Type::Domain => {
+            // Flush any already-buffered bulk objects first, so they keep the
+            // domain_sid they were collected under (matches the single-threaded
+            // ordering). In practice the domain object precedes the bulk, so the
+            // buffer is empty here.
+            parse_batch(buffer, results, domain, domain_sid.as_str(), count, total, pb)?;
+
+            let mut domain_object = Domain::new();
+            let domain_sid_from_domain = domain_object.parse(
+                entry,
+                domain,
+                &mut results.mappings.dn_sid,
+                &mut results.mappings.sid_type,
+                &results.mappings.schema_guid_map,
+            )?;
+            // Update only if domain_sid is valid
+            if domain_sid_from_domain != "DOMAIN_SID" && !domain_sid_from_domain.is_empty() {
+                *domain_sid = domain_sid_from_domain;
+            }
+            if !domain_object.object_identifier().is_empty() {
+                results.domains.push(domain_object);
+            }
+            update_progress(count, total, pb)?;
+        }
+        _ => {
+            buffer.push(entry);
+            if buffer.len() >= PARSE_BATCH {
+                parse_batch(buffer, results, domain, domain_sid.as_str(), count, total, pb)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+// Parse directly from a disk cache, decoding bincode records on worker threads.
+//
+// The reader thread only does cheap length-prefixed reads; the CPU-heavy
+// bincode decode happens inside a rayon batch, alongside the object parsing.
+// This keeps all cores busy on `--cache` / `--resume`, where the single-threaded
+// decode was previously the bottleneck.
+pub fn parse_result_type_from_disk(
+    common_args: &Options,
+    mut reader: DiskStorageReader<LdapSearchEntry>,
+    total_objects: Option<usize>,
+) -> Result<ADResults, Box<dyn Error>> {
+    let mut results = ADResults::default();
+    let domain = &common_args.domain;
+
+    let pb = ProgressBar::new(1);
+    let mut count = 0usize;
+    let total = total_objects;
+    let mut domain_sid: String = "DOMAIN_SID".to_owned();
+
+    log::info!("Starting the LDAP objects parsing...");
+
+    let mut raw_buf: Vec<Vec<u8>> = Vec::with_capacity(PARSE_BATCH);
+    let mut buffer: Vec<SearchEntry> = Vec::with_capacity(PARSE_BATCH);
+
+    loop {
+        match reader.next_raw() {
+            Some(Ok(blob)) => {
+                raw_buf.push(blob);
+                if raw_buf.len() >= PARSE_BATCH {
+                    decode_and_route(&mut raw_buf, &mut results, &mut buffer, domain, &mut domain_sid, &mut count, total, &pb)?;
+                }
+            }
+            Some(Err(e)) => return Err(e.into()),
+            None => break,
+        }
+    }
+
+    // Decode and route any remaining raw records, then parse the last bulk batch.
+    decode_and_route(&mut raw_buf, &mut results, &mut buffer, domain, &mut domain_sid, &mut count, total, &pb)?;
+    parse_batch(&mut buffer, &mut results, domain, &domain_sid, &mut count, total, &pb)?;
+
+    pb.finish_and_clear();
+    log::info!("Parsing LDAP objects finished!");
+    Ok(results)
+}
+
+/// Decode a batch of raw bincode records in parallel, then route each decoded
+/// entry (preserving stream order, so schema/domain are handled before bulk).
+#[allow(clippy::too_many_arguments)]
+fn decode_and_route(
+    raw_buf: &mut Vec<Vec<u8>>,
+    results: &mut ADResults,
+    buffer: &mut Vec<SearchEntry>,
+    domain: &str,
+    domain_sid: &mut String,
+    count: &mut usize,
+    total: Option<usize>,
+    pb: &ProgressBar,
+) -> Result<(), Box<dyn Error>> {
+    if raw_buf.is_empty() {
+        return Ok(());
+    }
+
+    let blobs = std::mem::take(raw_buf);
+
+    // The CPU-heavy bincode decode, spread across all cores.
+    let decoded: Vec<Result<SearchEntry, String>> = blobs
+        .into_par_iter()
+        .map(|data| {
+            bincode::decode_from_slice::<LdapSearchEntry, _>(&data, bincode::config::standard())
+                .map(|(entry, _)| SearchEntry::from(entry))
+                .map_err(|e| format!("Failed to decode item: {e:?}"))
+        })
+        .collect();
+
+    for decoded_entry in decoded {
+        let entry = decoded_entry.map_err(|e| -> Box<dyn Error> { e.into() })?;
+        route_entry(entry, results, buffer, domain, domain_sid, count, total, pb)?;
+    }
+
+    Ok(())
 }
 

--- a/src/enums/adcs.rs
+++ b/src/enums/adcs.rs
@@ -336,10 +336,16 @@ pub fn templates_enabled_change_displayname_to_sid(
         let mut enabled_cert_templates: Vec<Member> = Vec::new();
         for template in templates {
             let mut member = Member::new();
-            // println!("{:?}",&template.object_identifier());
-            if let Some(value) = name_sid.keys()
-            .find(|&key| key.contains(&template.object_identifier().to_uppercase()))
-            .and_then(|key| name_sid.get(key))
+            let needle = template.object_identifier().to_uppercase();
+            // When several template names match, pick the smallest key
+            // deterministically instead of relying on HashMap iteration order
+            // (which otherwise makes the published-templates edges vary run-to-run,
+            // affecting ADCS attack-path analysis).
+            if let Some(value) = name_sid
+                .keys()
+                .filter(|key| key.contains(&needle))
+                .min()
+                .and_then(|key| name_sid.get(key))
             {
                 *member.object_identifier_mut() = value.to_owned();
                 *member.object_type_mut() = template.object_type().to_owned();

--- a/src/json/checker/common.rs
+++ b/src/json/checker/common.rs
@@ -283,7 +283,17 @@ pub fn add_default_users(
 fn build_sid_to_dn(dn_sid: &HashMap<String, String>) -> HashMap<&str, &str> {
     let mut sid_to_dn: HashMap<&str, &str> = HashMap::with_capacity(dn_sid.len());
     for (dn, sid) in dn_sid {
-        sid_to_dn.entry(sid.as_str()).or_insert(dn.as_str());
+        // When a SID maps to several DNs, keep the lexicographically smallest so
+        // the choice is deterministic instead of dependent on HashMap iteration
+        // order (which otherwise makes e.g. ContainedBy vary run-to-run).
+        sid_to_dn
+            .entry(sid.as_str())
+            .and_modify(|existing| {
+                if dn.as_str() < *existing {
+                    *existing = dn.as_str();
+                }
+            })
+            .or_insert(dn.as_str());
     }
     sid_to_dn
 }

--- a/src/json/checker/common.rs
+++ b/src/json/checker/common.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::error::Error;
 
+use once_cell::sync::Lazy;
+use rayon::prelude::*;
 use regex::Regex;
 use crate::enums::ldaptype::*;
 use crate::objects::common::Link;
@@ -274,50 +276,57 @@ pub fn add_default_users(
     Ok(())
 }
 
+/// Build a reverse index from SID to DN once, so per-object lookups are O(1)
+/// instead of an O(n) linear scan over `dn_sid`. `dn_sid` values (SIDs) are
+/// effectively unique; when a SID maps to several DNs the first one wins, which
+/// matches the previous `.find()` behaviour.
+fn build_sid_to_dn(dn_sid: &HashMap<String, String>) -> HashMap<&str, &str> {
+    let mut sid_to_dn: HashMap<&str, &str> = HashMap::with_capacity(dn_sid.len());
+    for (dn, sid) in dn_sid {
+        sid_to_dn.entry(sid.as_str()).or_insert(dn.as_str());
+    }
+    sid_to_dn
+}
+
 /// This function is to push user SID in ChildObjects v2
-pub fn add_childobjects_members<T: LdapObject>(
+pub fn add_childobjects_members<T: LdapObject + Send>(
     vec_replaced: &mut [T],
     dn_sid: &HashMap<String, String>,
     sid_type: &HashMap<String, String>,
 ) -> Result<(), Box<dyn Error>> {
-    // Needed for progress bar stats
-    let total = vec_replaced.len();
-    let pb = ProgressBar::new(total as u64);
+    // Reverse index SID -> DN, built once (was an O(n) scan per object).
+    let sid_to_dn = build_sid_to_dn(dn_sid);
 
-    // Iterate over the objects
-    for (count, object) in vec_replaced.iter_mut().enumerate() {
-        // Update progress bar periodically
-        if count % (total / 100).max(1) == 0 {
-            pb.set_position(count as u64);
-        }
+    // Uppercase every DN a single time instead of once per object. The old code
+    // re-allocated an uppercased copy of every `dn_sid` key for every object,
+    // which was the O(n^2) allocation storm behind the multi-GB RAM use.
+    let dn_upper: Vec<(String, &String)> =
+        dn_sid.iter().map(|(dn, sid)| (dn.to_uppercase(), sid)).collect();
 
+    // Objects are independent; process them across all CPU cores.
+    vec_replaced.par_iter_mut().for_each(|object| {
         // Get the SID, DN, and name of the current object
         let sid = object.get_object_identifier().to_uppercase();
-        let dn = dn_sid
-            .iter()
-            .find(|(_, v)| **v == sid)
-            .map(|(k, _)| k)
-            .unwrap_or(&sid);
+        let dn: &str = sid_to_dn.get(sid.as_str()).copied().unwrap_or(sid.as_str());
         let name = get_name_from_full_distinguishedname(dn);
-        let _otype = sid_type.get(&sid).unwrap();
 
-        // Filter direct members from dn_sid
-        let direct_members: Vec<Member> = dn_sid
+        // Filter direct members from the pre-uppercased dn list
+        let direct_members: Vec<Member> = dn_upper
             .iter()
-            .filter_map(|(dn_object, value_sid)| {
-                let dn_object_upper = dn_object.to_uppercase();
-
+            .filter_map(|(dn_object_upper, value_sid)| {
                 // Check if dn_object is related to the current object's DN
                 if dn_object_upper.contains(dn)
-                    && &dn_object_upper != dn
-                    && dn_object_upper.split(',')
+                    && dn_object_upper.as_str() != dn
+                    && dn_object_upper
+                        .split(',')
                         .nth(1)
                         .and_then(|s| s.split('=').nth(1))
-                        == Some(&name)
+                        == Some(name.as_str())
                 {
                     let mut member = Member::new();
-                    *member.object_identifier_mut() = value_sid.clone();
-                    *member.object_type_mut() = sid_type.get(value_sid).unwrap_or(&value_sid).to_string();
+                    *member.object_identifier_mut() = (*value_sid).clone();
+                    *member.object_type_mut() =
+                        sid_type.get(*value_sid).unwrap_or(value_sid).to_string();
                     if !member.object_identifier().is_empty() {
                         return Some(member);
                     }
@@ -328,9 +337,8 @@ pub fn add_childobjects_members<T: LdapObject>(
 
         // Set direct members for the object
         object.set_child_objects(direct_members);
-    }
+    });
 
-    pb.finish_and_clear();
     Ok(())
 }
 
@@ -422,21 +430,12 @@ pub fn add_childobjects_members_for_ou(
 }
 
 /// This function checks GUID for all Gplinks and replaces them with the correct GUIDs
-pub fn replace_guid_gplink<T: LdapObject>(
+pub fn replace_guid_gplink<T: LdapObject + Send>(
     vec_replaced: &mut [T],
     dn_sid: &HashMap<String, String>,
 ) -> Result<(), Box<dyn Error>> {
-    // Progress bar setup
-    let total = vec_replaced.len();
-    let pb = ProgressBar::new(total as u64);
-
-    // Iterate over the objects
-    for (count, object) in vec_replaced.iter_mut().enumerate() {
-        // Update progress bar periodically
-        if count % (total / 100).max(1) == 0 {
-            pb.set_position(count as u64);
-        }
-
+    // Objects are independent; process them across all CPU cores.
+    vec_replaced.par_iter_mut().for_each(|object| {
         // Process links if they exist
         if !object.get_links().is_empty() {
             // Replace GUIDs in links
@@ -459,9 +458,8 @@ pub fn replace_guid_gplink<T: LdapObject>(
             // Update the object's links
             object.set_links(updated_links);
         }
-    }
+    });
 
-    pb.finish_and_clear();
     Ok(())
 }
 
@@ -497,77 +495,51 @@ pub fn add_affected_computers_for_ou(
     dn_sid: &HashMap<String, String>,
     sid_type: &HashMap<String, String>,
 ) -> Result<(), Box<dyn Error>> {
-    // Filter all computers DN:SID in advance
-    let dn_sid_filtered: Vec<(&String, &String)> = dn_sid
-        .iter()
-        .filter(|(_, sid)| sid_type.get(*sid).map(|t| t == "Computer").unwrap_or(false))
-        .collect();
-
-    // Map each OU's identifier to its DN
-    let ou_dn_map: HashMap<String, String> = vec_ous
-        .iter()
-        .filter_map(|ou| {
-            dn_sid
-                .iter()
-                .find_map(|(dn, sid)| {
-                    if *sid == *ou.get_object_identifier() {
-                        Some((ou.get_object_identifier().to_owned(), dn.clone()))
-                    } else {
-                        None
-                    }
-                })
-        })
-        .collect();
-
-    // For each OU, add affected computers
-    for ou in vec_ous.iter_mut() {
-        if let Some(ou_dn) = ou_dn_map.get(ou.get_object_identifier()) {
-            let vec_affected_computers: Vec<Member> = dn_sid_filtered
-                .iter()
-                .filter_map(|(dn, sid)| {
-                    if get_contained_by_name_from_distinguishedname(
-                        &get_cn_object_name_from_full_distinguishedname(dn),
-                        dn,
-                    ) == *ou_dn
-                    {
-                        let mut member = Member::new();
-                        *member.object_identifier_mut() = sid.to_string();
-                        *member.object_type_mut() = "Computer".to_string();
-                        Some(member)
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-
-            // Update GPO changes for the OU
-            let mut gpo_changes = GPOChange::new();
-            *gpo_changes.affected_computers_mut() = vec_affected_computers;
-            *ou.gpo_changes_mut() = gpo_changes;
+    // Group every computer under its parent DN a single time, so each OU is an
+    // O(1) lookup instead of a full scan over all computers (was O(OUs*computers)).
+    let mut computers_by_parent: HashMap<String, Vec<Member>> = HashMap::new();
+    for (dn, sid) in dn_sid {
+        if sid_type.get(sid).map(|t| t == "Computer").unwrap_or(false) {
+            let parent = get_contained_by_name_from_distinguishedname(
+                &get_cn_object_name_from_full_distinguishedname(dn),
+                dn,
+            );
+            let mut member = Member::new();
+            *member.object_identifier_mut() = sid.to_string();
+            *member.object_type_mut() = "Computer".to_string();
+            computers_by_parent.entry(parent).or_default().push(member);
         }
+    }
+
+    // Map each OU's identifier to its DN, using a reverse index built once
+    // instead of scanning `dn_sid` per OU.
+    let sid_to_dn = build_sid_to_dn(dn_sid);
+
+    // For each OU, attach the pre-grouped affected computers (empty list when
+    // none, matching the previous behaviour of always setting gpo_changes).
+    for ou in vec_ous.iter_mut() {
+        let Some(ou_dn) = sid_to_dn.get(ou.get_object_identifier().as_str()) else {
+            continue;
+        };
+        let affected = computers_by_parent.get(*ou_dn).cloned().unwrap_or_default();
+        let mut gpo_changes = GPOChange::new();
+        *gpo_changes.affected_computers_mut() = affected;
+        *ou.gpo_changes_mut() = gpo_changes;
     }
     Ok(())
 }
 
 /// This function replaces FQDN by SID in users' SPNTargets or computers' AllowedToDelegate
-pub fn replace_fqdn_by_sid<T: LdapObject>(
+pub fn replace_fqdn_by_sid<T: LdapObject + Send>(
     object_type: Type,
     vec_src: &mut [T],
     fqdn_sid: &HashMap<String, String>,
 ) -> Result<(), Box<dyn Error>> {
-    // Progress bar setup
-    let total = vec_src.len();
-    let pb = ProgressBar::new(total as u64);
-
-    // Process based on the object type
+    // Objects are independent and `fqdn_sid` is read-only, so process across all
+    // CPU cores.
     match object_type {
         Type::User => {
-            for (count, obj) in vec_src.iter_mut().enumerate() {
-                // Update progress bar
-                if count % (total / 100).max(1) == 0 {
-                    pb.set_position(count as u64);
-                }
-
+            vec_src.par_iter_mut().for_each(|obj| {
                 // Process SPNTargets
                 for target in obj.get_spntargets_mut().iter_mut() {
                     let sid = fqdn_sid
@@ -583,15 +555,10 @@ pub fn replace_fqdn_by_sid<T: LdapObject>(
                         .unwrap_or_else(|| target.object_identifier());
                     *target.object_identifier_mut() = sid.to_string();
                 }
-            }
+            });
         }
         Type::Computer => {
-            for (count, obj) in vec_src.iter_mut().enumerate() {
-                // Update progress bar
-                if count % (total / 100).max(1) == 0 {
-                    pb.set_position(count as u64);
-                }
-
+            vec_src.par_iter_mut().for_each(|obj| {
                 // Process AllowedToDelegate
                 for delegate in obj.get_allowed_to_delegate_mut().iter_mut() {
                     let sid = fqdn_sid
@@ -599,12 +566,11 @@ pub fn replace_fqdn_by_sid<T: LdapObject>(
                         .unwrap_or_else(|| delegate.object_identifier());
                     *delegate.object_identifier_mut() = sid.to_string();
                 }
-            }
+            });
         }
         _ => {}
     }
 
-    pb.finish_and_clear();
     Ok(())
 }
 
@@ -615,16 +581,11 @@ pub fn replace_sid_members(
     sid_type: &HashMap<String, String>,
     vec_trusts: &[Trust],
 ) -> Result<(), Box<dyn Error>> {
-    let total = vec_groups.len();
-    let pb = ProgressBar::new(total as u64);
-
     let default_type = "Group".to_string();
 
-    for (count, group) in vec_groups.iter_mut().enumerate() {
-        if count % (total / 100).max(1) == 0 {
-            pb.set_position(count as u64);
-        }
-
+    // Groups are independent and the maps/trusts are read-only, so resolve
+    // members across all CPU cores.
+    vec_groups.par_iter_mut().for_each(|group| {
         for member in group.members_mut() {
             let member_dn = member.object_identifier();
 
@@ -646,17 +607,21 @@ pub fn replace_sid_members(
             }
 
             // 3) Fallback: try trusts
-            let generated_sid = sid_maker_from_another_domain(vec_trusts, member_dn)?;
-            if !generated_sid.is_empty() {
-                *member.object_identifier_mut() = generated_sid;
-                *member.object_type_mut() = default_type.clone();
-            } else {
-                error!("Could not resolve SID for member DN: {}", member_dn);
+            match sid_maker_from_another_domain(vec_trusts, member_dn) {
+                Ok(generated_sid) if !generated_sid.is_empty() => {
+                    *member.object_identifier_mut() = generated_sid;
+                    *member.object_type_mut() = default_type.clone();
+                }
+                Ok(_) => {
+                    error!("Could not resolve SID for member DN: {}", member_dn);
+                }
+                Err(e) => {
+                    error!("Failed to resolve member DN {}: {}", member_dn, e);
+                }
             }
         }
-    }
+    });
 
-    pb.finish_and_clear();
     Ok(())
 }
 
@@ -665,8 +630,10 @@ fn sid_maker_from_another_domain(
     vec_trusts: &[Trust],
     object_identifier: &String,
 ) -> Result<String, Box<dyn Error>> {
-    // Create the regex for SID matching
-    let sid_regex = Regex::new(r"S-[0-9]+-[0-9]+-[0-9]+(?:-[0-9]+)+")?;
+    // Regex for SID matching, compiled once instead of on every call.
+    static SID_REGEX: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"S-[0-9]+-[0-9]+-[0-9]+(?:-[0-9]+)+").unwrap());
+    let sid_regex = &*SID_REGEX;
 
     // Check if the object_identifier matches any trusted domain
     for trust in vec_trusts {
@@ -694,22 +661,38 @@ fn get_id_from_objectidentifier(
     object_identifier: &str
 ) -> Result<String, Box<dyn Error>> {
 
-    // Static mapping of group names to RIDs
+    // Static mapping of built-in group names to their well-known RIDs.
+    //
+    // NOTE: the French-language entries are intentional and REQUIRED, not
+    // untranslated text. On a French-locale Domain Controller the built-in
+    // groups are returned by LDAP under their localized names (e.g. "Domain
+    // Admins" is literally "Administrateurs du domaine"), so each RID is
+    // matched from both its English and French display name. Removing the
+    // French names would break well-known-SID resolution on French domains.
+    // Additional locales can be added here following the same pattern.
     const NAME_TO_RID: [(&str, &str); 16] = [
+        // -512  Domain Admins
         ("DOMAIN ADMINS", "-512"),
         ("ADMINISTRATEURS DU DOMAINE", "-512"),
+        // -513  Domain Users
         ("DOMAIN USERS", "-513"),
         ("UTILISATEURS DU DOMAINE", "-513"),
+        // -514  Domain Guests
         ("DOMAIN GUESTS", "-514"),
         ("INVITES DE DOMAINE", "-514"),
+        // -515  Domain Computers
         ("DOMAIN COMPUTERS", "-515"),
         ("ORDINATEURS DE DOMAINE", "-515"),
+        // -516  Domain Controllers
         ("DOMAIN CONTROLLERS", "-516"),
         ("CONTRÔLEURS DE DOMAINE", "-516"),
+        // -517  Cert Publishers
         ("CERT PUBLISHERS", "-517"),
         ("EDITEURS DE CERTIFICATS", "-517"),
+        // -518  Schema Admins
         ("SCHEMA ADMINS", "-518"),
         ("ADMINISTRATEURS DU SCHEMA", "-518"),
+        // -519  Enterprise Admins
         ("ENTERPRISE ADMINS", "-519"),
         ("ADMINISTRATEURS DE L'ENTREPRISE", "-519"),
     ];
@@ -748,25 +731,16 @@ pub fn add_trustdomain(
 }
 
 /// This function checks PrincipalSID for all ACEs and adds the PrincipalType ("Group", "User", "Computer") v2
-pub fn add_type_for_ace<T: LdapObject>(
+pub fn add_type_for_ace<T: LdapObject + Send>(
     object: &mut [T],
     sid_type: &HashMap<String, String>,
 ) -> Result<(), Box<dyn Error>> {
-    // Progress bar setup
-    let total = object.len();
-    let pb = ProgressBar::new(total as u64);
-
     // Default type for unmatched SIDs
     let default_type = "Group".to_string();
 
-    // Iterate over each object
-    for (count, obj) in object.iter_mut().enumerate() {
-        // Update progress bar
-        if count % (total / 100).max(1) == 0 {
-            pb.set_position(count as u64);
-        }
-
-        // Get mutable reference to ACEs
+    // Each object's ACEs are independent and `sid_type` is read-only here, so
+    // this is embarrassingly parallel: spread it across all CPU cores.
+    object.par_iter_mut().for_each(|obj| {
         for ace in obj.get_aces_mut() {
             // Fetch the type from sid_type or use the default
             let type_object = sid_type
@@ -777,9 +751,8 @@ pub fn add_type_for_ace<T: LdapObject>(
             // Update the principal type
             *ace.principal_type_mut() = type_object;
         }
-    }
+    });
 
-    pb.finish_and_clear();
     Ok(())
 }
 
@@ -788,20 +761,11 @@ pub fn add_type_for_allowtedtoact(
     computer: &mut [Computer],
     sid_type: &HashMap<String, String>,
 ) -> Result<(), Box<dyn Error>> {
-    // Progress bar setup
-    let total = computer.len();
-    let pb = ProgressBar::new(total as u64);
-
     // Default type for unmatched SIDs
     let default_type = "Computer".to_string();
 
-    // Iterate over all computers
-    for (count, comp) in computer.iter_mut().enumerate() {
-        // Update progress bar periodically
-        if count % (total / 100).max(1) == 0 {
-            pb.set_position(count as u64);
-        }
-
+    // Computers are independent; process them across all CPU cores.
+    computer.par_iter_mut().for_each(|comp| {
         // Process all AllowedToAct objects
         for allowed in comp.allowed_to_act_mut() {
             let type_object = sid_type
@@ -811,58 +775,54 @@ pub fn add_type_for_allowtedtoact(
 
             *allowed.object_type_mut() = type_object;
         }
-    }
+    });
 
-    pb.finish_and_clear();
     Ok(())
 }
 
 /// This function pushes user SID into ChildObjects for Ou v2
-pub fn add_contained_by_for<T: LdapObject>(
+pub fn add_contained_by_for<T: LdapObject + Send>(
     vec_replaced: &mut [T],
-    dn_sid: &HashMap<String, String>, 
+    dn_sid: &HashMap<String, String>,
     sid_type: &HashMap<String, String>,
 ) -> Result<(), Box<dyn Error>> {
-    // Progress bar setup
-    let total = vec_replaced.len();
-    let pb = ProgressBar::new(total as u64);
-
     // Default type for unmatched SIDs
     let default_type = "Group".to_string();
 
-    for (count, object) in vec_replaced.iter_mut().enumerate() {
-        // Update progress bar periodically
-        if count % (total / 100).max(1) == 0 {
-            pb.set_position(count as u64);
-        }
+    // Reverse index SID -> DN, built once. This used to be an O(n) linear scan
+    // over `dn_sid` *per object* (`dn_sid.iter().find_map(...)`), i.e. O(n^2)
+    // over the whole dataset — the dominant hang on large domains.
+    let sid_to_dn = build_sid_to_dn(dn_sid);
 
+    // Each object is independent and the maps are read-only here, so fan the
+    // work out across all CPU cores.
+    vec_replaced.par_iter_mut().for_each(|object| {
         // Fetch SID and DN for the current object
         let sid = object.get_object_identifier();
-        let dn = dn_sid.iter().find_map(|(key, value)| if value == sid { Some(key) } else { None });
+        let Some(dn) = sid_to_dn.get(sid.as_str()).copied() else {
+            return;
+        };
 
-        if let Some(dn) = dn {
-            let otype = sid_type.get(sid).unwrap_or(&default_type);
+        let otype = sid_type.get(sid).unwrap_or(&default_type);
+        if otype != "Domain" {
+            // Extract CN name and contained-by name
+            let dn_owned = dn.to_string();
+            let cn_name = get_cn_object_name_from_full_distinguishedname(&dn_owned);
+            let contained_by_name = get_contained_by_name_from_distinguishedname(&cn_name, &dn_owned);
 
-            if otype != "Domain" {
-                // Extract CN name and contained-by name
-                let cn_name = get_cn_object_name_from_full_distinguishedname(dn);
-                let contained_by_name = get_contained_by_name_from_distinguishedname(&cn_name, dn);
+            // Check if the contained-by name exists in dn_sid
+            if let Some(sid_contained_by) = dn_sid.get(&contained_by_name) {
+                let type_contained_by = sid_type.get(sid_contained_by).unwrap_or(&default_type);
 
-                // Check if the contained-by name exists in dn_sid
-                if let Some(sid_contained_by) = dn_sid.get(&contained_by_name) {
-                    let type_contained_by = sid_type.get(sid_contained_by).unwrap_or(&default_type);
-
-                    // Create and set the contained_by Member
-                    let mut contained_by = Member::new();
-                    *contained_by.object_identifier_mut() = sid_contained_by.to_string();
-                    *contained_by.object_type_mut() = type_contained_by.to_string();
-                    object.set_contained_by(Some(contained_by));
-                }
+                // Create and set the contained_by Member
+                let mut contained_by = Member::new();
+                *contained_by.object_identifier_mut() = sid_contained_by.to_string();
+                *contained_by.object_type_mut() = type_contained_by.to_string();
+                object.set_contained_by(Some(contained_by));
             }
         }
-    }
+    });
 
-    pb.finish_and_clear();
     Ok(())
 }
 

--- a/src/json/maker/common.rs
+++ b/src/json/maker/common.rs
@@ -1,110 +1,183 @@
 use obfstr::obfstr;
 
-use serde_json::value::Value;
+use serde::Serialize;
 
-use std::collections::HashMap;
 use colored::Colorize;
 use log::{info, debug, trace};
+use rayon::prelude::*;
 
 use std::fs;
 use std::fs::File;
-use std::io::{Seek, Write};
+use std::io::{BufWriter, Write};
 use std::error::Error;
 
-use zip::result::ZipResult;
 use zip::write::{SimpleFileOptions, ZipWriter};
 
 extern crate zip;
 use crate::args::{Options, RUSTHOUND_VERSION};
-use crate::objects::common::{FinalJson, Meta, LdapObject};
+use crate::objects::common::{Meta, LdapObject};
 
 /// Current Bloodhound version 4.3+
 pub const BLOODHOUND_VERSION_4: i8 = 6;
 
-// Function to create the .json file.
-pub fn add_file<T: LdapObject>(
-   datetime: &String,
-   name: String,
-   domain_format: &String,
-   vec_json: Vec<T>,
-   json_result: &mut HashMap<String, String>,
-   common_args: &Options, 
- ) -> std::io::Result<()>
- {
-  if !vec_json.is_empty() {
-    debug!("Making {}.json",&name);
-  
-    let path = &common_args.path;
-    let zip = common_args.zip;
+/// Number of objects serialized per parallel batch.
+///
+/// Objects in a batch are serialized to JSON concurrently (using all CPU
+/// cores) then flushed sequentially to the output, so peak extra memory is
+/// bounded by one batch instead of the whole dataset.
+const SERIALIZE_BATCH: usize = 4096;
+
+/// Where a JSON collection is written: either straight into an entry of the
+/// shared zip archive, or into its own `.json` file on disk.
+enum Sink<'a> {
+    Zip(&'a mut ZipWriter<BufWriter<File>>),
+    Dir { path: &'a str, datetime: &'a str, domain: &'a str },
+}
+
+/// Stream one object collection as a BloodHound JSON document
+/// (`{"data":[...],"meta":{...}}`) into `writer`, without ever materialising
+/// the whole document (or a `serde_json::Value` DOM) in memory.
+///
+/// Objects are serialized in parallel batches, which is both faster on
+/// many-core machines and keeps memory flat regardless of object count.
+fn write_json_document<T, W>(writer: &mut W, name: &str, vec_json: &[T]) -> std::io::Result<()>
+where
+    T: LdapObject + Serialize + Sync,
+    W: Write,
+{
     let count = vec_json.len();
-  
-    let mut result: Vec<Value> = Vec::new();
-    for object in vec_json {
-        result.push(object.to_json().to_owned());
+
+    writer.write_all(b"{\"data\":[")?;
+
+    let mut first = true;
+    for batch in vec_json.chunks(SERIALIZE_BATCH) {
+        // Serialize every object of this batch concurrently across all cores.
+        let parts: Vec<String> = batch
+            .par_iter()
+            .map(|object| serde_json::to_string(object).expect("object serialization failed"))
+            .collect();
+
+        for part in parts {
+            if !first {
+                writer.write_all(b",")?;
+            }
+            first = false;
+            writer.write_all(part.as_bytes())?;
+        }
     }
-    // Prepare template and get result in const var
-    let final_json = FinalJson::new(
-        result,
-        Meta::new(
-          000000_i32,
-          name.to_owned(),
-          count as i32,
-          BLOODHOUND_VERSION_4,
-          format!("RustHound-CE v{}",RUSTHOUND_VERSION.to_owned())
-        )
+
+    let meta = Meta::new(
+        0_i32,
+        name.to_owned(),
+        count as i32,
+        BLOODHOUND_VERSION_4,
+        format!("RustHound-CE v{}", RUSTHOUND_VERSION.to_owned()),
     );
-  
-    info!("{} {} parsed!", count.to_string().bold(),&name);
-  
-    // result
+    writer.write_all(b"],\"meta\":")?;
+    serde_json::to_writer(&mut *writer, &meta)?;
+    writer.write_all(b"}")?;
+
+    Ok(())
+}
+
+/// Emit one object collection to the selected [`Sink`]. Empty collections are
+/// skipped, matching the previous behaviour (no file/entry is created).
+fn emit<T>(sink: &mut Sink, name: &str, vec_json: &[T]) -> Result<(), Box<dyn Error>>
+where
+    T: LdapObject + Serialize + Sync,
+{
+    if vec_json.is_empty() {
+        return Ok(());
+    }
+
+    let count = vec_json.len();
+    debug!("Making {name}.json");
+
+    match sink {
+        Sink::Zip(writer) => {
+            // `large_file(true)` enables ZIP64, which is required for any entry
+            // larger than 4 GiB. Without it the zip crate errors out on huge
+            // domains, which is what caused the crash on large outputs.
+            let options = SimpleFileOptions::default()
+                .compression_method(zip::CompressionMethod::Deflated)
+                .large_file(true);
+            let filename = format!("{name}.json");
+            trace!("Adding file {}", filename.bold());
+            writer.start_file(&filename, options)?;
+            write_json_document(*writer, name, vec_json)?;
+        }
+        Sink::Dir { path, datetime, domain } => {
+            let final_path = format!("{path}/{datetime}_{domain}_{name}.json");
+            let file = File::create(&final_path)?;
+            let mut buf = BufWriter::new(file);
+            write_json_document(&mut buf, name, vec_json)?;
+            buf.flush()?;
+            info!("{} created!", final_path.bold());
+        }
+    }
+
+    info!("{} {name} parsed!", count.to_string().bold());
+    Ok(())
+}
+
+/// Emit every object collection contained in `ad_results` into the given sink.
+macro_rules! emit_all {
+    ($sink:expr, $ad:expr) => {{
+        emit($sink, "users", &$ad.users)?;
+        emit($sink, "groups", &$ad.groups)?;
+        emit($sink, "computers", &$ad.computers)?;
+        emit($sink, "ous", &$ad.ous)?;
+        emit($sink, "domains", &$ad.domains)?;
+        emit($sink, "gpos", &$ad.gpos)?;
+        emit($sink, "containers", &$ad.containers)?;
+        emit($sink, "ntauthstores", &$ad.ntauthstores)?;
+        emit($sink, "aiacas", &$ad.aiacas)?;
+        emit($sink, "rootcas", &$ad.rootcas)?;
+        emit($sink, "enterprisecas", &$ad.enterprisecas)?;
+        emit($sink, "certtemplates", &$ad.certtemplates)?;
+        emit($sink, "issuancepolicies", &$ad.issuancepolicies)?;
+    }};
+}
+
+/// Write all collections as individual `.json` files on disk.
+pub fn write_json_files(
+    datetime: &str,
+    domain_format: &str,
+    common_args: &Options,
+    ad_results: &crate::api::ADResults,
+) -> Result<(), Box<dyn Error>> {
+    fs::create_dir_all(&common_args.path)?;
+    let mut sink = Sink::Dir {
+        path: &common_args.path,
+        datetime,
+        domain: domain_format,
+    };
+    emit_all!(&mut sink, ad_results);
+    Ok(())
+}
+
+/// Stream all collections into a single zip archive.
+pub fn make_a_zip(
+    datetime: &str,
+    domain: &str,
+    path: &str,
+    ad_results: &crate::api::ADResults,
+) -> Result<String, Box<dyn Error>> {
     fs::create_dir_all(path)?;
-  
-    // Create json file if isn't zip
-    if ! zip 
+    let final_path = format!("{path}/{datetime}_{domain}_{}.zip", obfstr!("rusthound-ce"));
+
+    let file = File::create(&final_path)?;
+    // A large buffer keeps the single-threaded deflate stream fed and cuts
+    // syscall overhead on multi-GB archives.
+    let mut writer = ZipWriter::new(BufWriter::with_capacity(1 << 20, file));
+
+    trace!("Making the ZIP file");
     {
-        let final_path = format!("{}/{}_{}_{}.json",path,datetime,domain_format,name);
-        fs::write(&final_path, serde_json::to_string(&final_json)?)?;
-        info!("{} created!",final_path.bold());
+        let mut sink = Sink::Zip(&mut writer);
+        emit_all!(&mut sink, ad_results);
     }
-    else
-    {
-        json_result.insert(format!("{}_{}_{}.json",datetime,domain_format,name).to_string(),serde_json::to_string(&final_json)?);
-    }
-  }
-  Ok(())
- }
- 
- /// Function to compress the JSON files into a zip archive
- pub fn make_a_zip(
-   datetime: &String,
-   domain: &String,
-   path: &String,
-   json_result: &HashMap<String, String>
- ) -> Result<String, Box<dyn Error>> {
-   let final_path = format!("{}/{}_{}_{}.zip",path,datetime,domain,obfstr!("rusthound-ce"));
-   let mut file = File::create(&final_path).expect("Couldn't create file");
-   create_zip_archive(&mut file, json_result).expect("Couldn't create archive");
- 
-   info!("{} created!",&final_path.bold());
-   Ok(final_path)
- }
- 
- 
- fn create_zip_archive<T: Seek + Write>(zip_filename: &mut T,json_result: &HashMap<String, String>) -> ZipResult<()> {
-   let mut writer = ZipWriter::new(zip_filename);
-   // json file by json file
-   trace!("Making the ZIP file");
- 
-   for file in json_result
-   {
-      let filename = file.0;
-      let content = file.1;
-      trace!("Adding file {}",filename.bold());
-      let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
-      writer.start_file(filename, options)?;
-      writer.write_all(content.as_bytes())?;
-   }
- 
-   writer.finish()?;
-   Ok(())
- }
+    writer.finish()?.flush()?;
+
+    info!("{} created!", &final_path.bold());
+    Ok(final_path)
+}

--- a/src/json/maker/common.rs
+++ b/src/json/maker/common.rs
@@ -30,7 +30,7 @@ const SERIALIZE_BATCH: usize = 4096;
 /// Where a JSON collection is written: either straight into an entry of the
 /// shared zip archive, or into its own `.json` file on disk.
 enum Sink<'a> {
-    Zip(&'a mut ZipWriter<BufWriter<File>>),
+    Zip { writer: &'a mut ZipWriter<BufWriter<File>>, datetime: &'a str, domain: &'a str },
     Dir { path: &'a str, datetime: &'a str, domain: &'a str },
 }
 
@@ -94,14 +94,15 @@ where
     debug!("Making {name}.json");
 
     match sink {
-        Sink::Zip(writer) => {
+        Sink::Zip { writer, datetime, domain } => {
             // `large_file(true)` enables ZIP64, which is required for any entry
             // larger than 4 GiB. Without it the zip crate errors out on huge
             // domains, which is what caused the crash on large outputs.
             let options = SimpleFileOptions::default()
                 .compression_method(zip::CompressionMethod::Deflated)
                 .large_file(true);
-            let filename = format!("{name}.json");
+            // Keep the original entry naming scheme: <datetime>_<domain>_<name>.json
+            let filename = format!("{datetime}_{domain}_{name}.json");
             trace!("Adding file {}", filename.bold());
             writer.start_file(&filename, options)?;
             write_json_document(*writer, name, vec_json)?;
@@ -173,7 +174,7 @@ pub fn make_a_zip(
 
     trace!("Making the ZIP file");
     {
-        let mut sink = Sink::Zip(&mut writer);
+        let mut sink = Sink::Zip { writer: &mut writer, datetime, domain };
         emit_all!(&mut sink, ad_results);
     }
     writer.finish()?.flush()?;

--- a/src/json/maker/mod.rs
+++ b/src/json/maker/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::error::Error;
 
 extern crate zip;
@@ -7,130 +6,22 @@ use crate::args::Options;
 use crate::utils::date::return_current_fulldate;
 pub mod common;
 
-/// This function will create json output and zip output
+/// This function will create json output and zip output.
+///
+/// Objects are streamed directly to disk / into the zip archive instead of
+/// being fully materialised in memory first, so it stays flat on RAM even for
+/// domains with millions of objects.
 pub fn make_result(common_args: &Options, ad_results: ADResults) -> Result<String, Box<dyn Error>> {
    // Format domain name
-   let filename = common_args.domain.replace(".", "-").to_lowercase();
-
-   // Hashmap for json files
-   let mut json_result: HashMap<String, String> = HashMap::new();
+   let filename = common_args.domain.replace('.', "-").to_lowercase();
 
    // Datetime for output file
    let datetime = return_current_fulldate();
 
-   // Add all in json files
-   common::add_file(
-      &datetime,
-      "users".to_string(),
-		&filename,
-      ad_results.users,
-      &mut json_result,
-      common_args,
-   )?;
-   common::add_file(
-      &datetime,
-      "groups".to_string(),
-		&filename,
-      ad_results.groups,
-      &mut json_result,
-      common_args,
-   )?;
-   common::add_file(
-      &datetime,
-      "computers".to_string(),
-		&filename,
-      ad_results.computers,
-      &mut json_result,
-      common_args,
-   )?;
-   common::add_file(
-      &datetime,
-      "ous".to_string(),
-		&filename,
-      ad_results.ous,
-      &mut json_result,
-      common_args,
-   )?;
-   common::add_file(
-      &datetime,
-      "domains".to_string(),
-		&filename,
-      ad_results.domains,
-      &mut json_result,
-      common_args,
-   )?;
-   common::add_file(
-      &datetime,
-      "gpos".to_string(),
-      &filename,
-      ad_results.gpos,
-      &mut json_result,
-      common_args,
-   )?;
-   // }
-   common::add_file(
-      &datetime,
-      "containers".to_string(),
-		&filename,
-      ad_results.containers,
-      &mut json_result,
-      common_args,
-   )?;
-   common::add_file(
-      &datetime,
-      "ntauthstores".to_string(),
-		&filename,
-      ad_results.ntauthstores,
-      &mut json_result,
-      common_args,
-   )?;
-   common::add_file(
-      &datetime,
-      "aiacas".to_string(),
-		&filename,
-      ad_results.aiacas,
-      &mut json_result,
-      common_args,
-   )?;
-   common::add_file(
-      &datetime,
-      "rootcas".to_string(),
-		&filename,
-      ad_results.rootcas,
-      &mut json_result,
-      common_args,
-   )?;
-   common::add_file(
-      &datetime,
-      "enterprisecas".to_string(),
-		&filename,
-      ad_results.enterprisecas,
-      &mut json_result,
-      common_args,
-   )?;
-   common::add_file(
-      &datetime,
-      "certtemplates".to_string(),
-		&filename,
-      ad_results.certtemplates,
-      &mut json_result,
-      common_args,
-   )?;
-   common::add_file(
-      &datetime,
-      "issuancepolicies".to_string(),
-		&filename,
-      ad_results.issuancepolicies,
-      &mut json_result,
-      common_args,
-   )?;
-   // All in zip file
    if common_args.zip {
-      return Ok(common::make_a_zip(
-         &datetime,
-         &filename,
-         &common_args.path,
-         &json_result)?)
+      return common::make_a_zip(&datetime, &filename, &common_args.path, &ad_results);
    }
+
+   common::write_json_files(&datetime, &filename, common_args, &ad_results)?;
    Ok(String::from("No zip full path"))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,5 +110,5 @@ pub use ldap::ldap_search;
 pub use ldap3::SearchEntry;
 
 pub use json::maker::make_result;
-pub use api::prepare_results_from_source;
+pub use api::{prepare_results_from_source, prepare_results_from_disk};
 pub use storage::{Storage, EntrySource, DiskStorage, DiskStorageReader};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,14 @@
 pub mod banner;
 pub mod modules;
 
+// Scalable multithreaded allocator. The default OS allocator (the Windows
+// process heap in particular) serializes concurrent allocations behind a lock,
+// which throttled every parallel phase — decode, parse, and the checker all
+// allocate heavily, so threads spent their time contending instead of working.
+// mimalloc uses per-thread heaps and removes that bottleneck.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use env_logger::Builder;
 use log::{error, info, trace};
 
@@ -54,7 +62,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 .join(CACHE_FILE);
             info!("Resuming from cache: {}", format!("{}",ldap_cache_path.display()).bold());
             let cache = DiskStorageReader::from_path(ldap_cache_path)?;
-            rusthound_ce::prepare_results_from_source(cache, &common_args, None).await?
+            rusthound_ce::prepare_results_from_disk(cache, &common_args, None).await?
         }
         false => {
             if common_args.cache {
@@ -89,7 +97,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 )
                 .await?;
 
-                rusthound_ce::prepare_results_from_source(
+                rusthound_ce::prepare_results_from_disk(
                     cache_writer.into_reader()?,
                     &common_args,
                     Some(total_cached),

--- a/src/objects/computer.rs
+++ b/src/objects/computer.rs
@@ -131,9 +131,16 @@ impl Computer {
         for (key, value) in &result_attrs {
             match key.as_str() {
                 "name" => {
-                    let name = &value[0];
-                    let email = format!("{}.{}",name.to_owned(),domain);
-                    self.properties.name = email.to_uppercase();
+                    // dNSHostName (the FQDN) is the canonical computer name and
+                    // must win. Only fall back to the `name` attribute when there
+                    // is no dNSHostName; otherwise, since both arms write
+                    // properties.name, the winner would depend on HashMap
+                    // iteration order and vary run-to-run.
+                    if !result_attrs.contains_key("dNSHostName") {
+                        let name = &value[0];
+                        let email = format!("{}.{}",name.to_owned(),domain);
+                        self.properties.name = email.to_uppercase();
+                    }
                 }
                 "sAMAccountName" => {
                     self.properties.samaccountname = value[0].to_owned();

--- a/src/objects/user.rs
+++ b/src/objects/user.rs
@@ -195,7 +195,7 @@ impl User {
                     let mut seen = HashSet::<String>::new();
 
                     for spn_raw in value {
-                        // Normalise: trim, remplace '\' par '/', insensible à la casse
+                        // Normalize: trim, replace '\' with '/', case-insensitive
                         let spn = spn_raw.trim().replace('\\', "/");
                         // SPN need to be: service/host[:port][/...]
                         let host_part = spn
@@ -216,7 +216,7 @@ impl User {
                         // Save it 
                         if seen.insert(fqdn_upper.clone()) {
                             let mut m = Member::new();
-                            *m.object_identifier_mut() = fqdn_upper; // déjà uppercase
+                            *m.object_identifier_mut() = fqdn_upper; // already uppercase
                             *m.object_type_mut() = "Computer".to_string();
                             vec_members2.push(m);
                         }

--- a/src/storage/iter.rs
+++ b/src/storage/iter.rs
@@ -46,6 +46,31 @@ where
     }
 }
 
+impl<T, R: Read> BincodeIterator<T, R> {
+    /// Read the next length-prefixed record as raw bytes, WITHOUT decoding it.
+    ///
+    /// Decoding (bincode) is CPU-heavy; reading the raw blob here (cheap I/O)
+    /// lets the caller push the decode work onto worker threads instead of
+    /// paying for it single-threaded on the reader thread.
+    pub fn next_raw(&mut self) -> Option<std::io::Result<Vec<u8>>> {
+        let mut len_bytes = [0u8; 4];
+        match self.reader.read_exact(&mut len_bytes) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return None,
+            Err(e) => return Some(Err(e)),
+        }
+
+        let len = u32::from_le_bytes(len_bytes) as usize;
+
+        let mut data = vec![0u8; len];
+        if let Err(e) = self.reader.read_exact(&mut data) {
+            return Some(Err(e));
+        }
+
+        Some(Ok(data))
+    }
+}
+
 impl<T, R: Read> Iterator for BincodeIterator<T, R>
 where
     T: bincode::Decode<()>,


### PR DESCRIPTION
Three places resolved values by taking the first match from a HashMap, so output
varied run-to-run for identical input:
- computer name: `name` and `dNSHostName` both wrote properties.name in HashMap
  order; give dNSHostName (the FQDN) precedence.
- reverse SID->DN lookup: keep the lexicographically smallest DN, not the first
  seen (stabilizes ContainedBy).
- EnterpriseCA EnabledCertTemplates: pick the smallest matching key instead of a
  random one — these edges feed ADCS attack-path analysis.