### PR TITLE
feat: replace SSPI PTH hack with pure-Rust ntlmssp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,36 +209,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-dnssd"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d49ffe175ab45bbfd74b548313d9d7cdfff27161a94b007b52eeeb5f9aaa15e"
-dependencies = [
- "bitflags 1.3.2",
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-util",
- "libc",
- "log",
- "pin-utils",
- "pkg-config",
- "tokio",
- "winapi",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,29 +224,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "pkg-config",
-]
 
 [[package]]
 name = "base16ct"
@@ -322,7 +269,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -335,12 +282,6 @@ dependencies = [
  "shlex 1.3.0",
  "syn 2.0.104",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -400,8 +341,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex 2.0.1",
 ]
 
@@ -483,15 +422,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,7 +497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d4ddf7139e64dc916b11d434421031bcc5ba02e521a49a011652a0f68775188"
 dependencies = [
  "anyhow",
- "bitflags 2.13.1",
+ "bitflags",
  "bytes",
  "libgssapi",
  "windows",
@@ -603,16 +533,6 @@ dependencies = [
  "generic-array",
  "rand_core",
  "typenum",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
-dependencies = [
- "generic-array",
- "subtle",
 ]
 
 [[package]]
@@ -747,12 +667,6 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
@@ -910,12 +824,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,18 +932,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
 ]
 
 [[package]]
@@ -1349,16 +1245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,8 +1275,7 @@ dependencies = [
 [[package]]
 name = "lber"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbcf559624bfd9fe8d488329a8959766335a43a9b8b2cdd6a2c379fca02909a5"
+source = "git+https://github.com/icedracon/ldap3-ntlmssp?branch=feat%2Fntlmssp-pth#287bffd8fd88903c51513cf0f67c413d227ae5f0"
 dependencies = [
  "bytes",
  "nom",
@@ -1399,8 +1284,7 @@ dependencies = [
 [[package]]
 name = "ldap3"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fe89f5e7cfb7e4701e3a38ff9f00358e026a9aee940355d88ee9d81e5c7503"
+source = "git+https://github.com/icedracon/ldap3-ntlmssp?branch=feat%2Fntlmssp-pth#287bffd8fd88903c51513cf0f67c413d227ae5f0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1411,11 +1295,11 @@ dependencies = [
  "lber",
  "log",
  "nom",
+ "ntlmssp",
  "percent-encoding",
  "ring",
  "rustls",
  "rustls-native-certs",
- "sspi",
  "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
@@ -1437,7 +1321,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff9fa7cfcdd777afd6dee929f8b19732bd2c52fe13c3105f00b7de3a2335a6c"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "bytes",
  "lazy_static",
  "libgssapi-sys",
@@ -1578,6 +1462,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntlmssp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c082c39c4f89145da2e663af77d1b5a267b50db36a14b802f990218afe1daa"
+dependencies = [
+ "hmac",
+ "md-5",
+ "md4",
+ "rand",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,17 +1506,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
 
 [[package]]
 name = "num-integer"
@@ -1849,7 +1735,6 @@ dependencies = [
  "oid",
  "serde",
  "serde_bytes",
- "time",
  "zeroize",
 ]
 
@@ -1876,7 +1761,6 @@ dependencies = [
  "picky-asn1",
  "picky-asn1-der",
  "serde",
- "widestring",
  "zeroize",
 ]
 
@@ -2033,12 +1917,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,7 +1943,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom",
 ]
 
 [[package]]
@@ -2083,7 +1961,7 @@ version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -2139,7 +2017,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -2170,7 +2048,6 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core",
- "sha1",
  "signature",
  "spki",
  "subtle",
@@ -2207,7 +2084,7 @@ name = "rusthound-ce"
 version = "2.5.2"
 dependencies = [
  "bincode",
- "bitflags 2.13.1",
+ "bitflags",
  "chrono",
  "clap",
  "colored",
@@ -2248,7 +2125,6 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2285,7 +2161,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2338,7 +2213,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2520,50 +2395,6 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
-]
-
-[[package]]
-name = "sspi"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523f6a99e26c1e6476a424d54bbda5354a01ee7f18b9d93dc48a8fd45ae8189b"
-dependencies = [
- "async-dnssd",
- "async-recursion",
- "bitflags 2.13.1",
- "byteorder",
- "cfg-if",
- "crypto-mac",
- "futures",
- "hmac",
- "lazy_static",
- "md-5",
- "md4",
- "num-bigint-dig",
- "num-derive",
- "num-traits",
- "oid",
- "picky",
- "picky-asn1",
- "picky-asn1-der",
- "picky-asn1-x509",
- "picky-krb",
- "rand",
- "rsa",
- "rustls",
- "serde",
- "serde_derive",
- "sha1",
- "sha2",
- "time",
- "tokio",
- "tracing",
- "url",
- "uuid",
- "windows",
- "windows-registry",
- "windows-sys 0.60.2",
- "zeroize",
 ]
 
 [[package]]
@@ -2935,10 +2766,7 @@ version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
- "getrandom 0.3.4",
- "js-sys",
  "serde_core",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2958,15 +2786,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -3041,28 +2860,6 @@ name = "widestring"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
@@ -3152,17 +2949,6 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core",
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
-dependencies = [
- "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
 ]
 
 [[package]]
@@ -3441,12 +3227,6 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ x509-parser = "0.16"
 trust-dns-resolver = "0.23"
 zip = { version = "4.2.0", default-features = false, features = ["deflate"] }
 rpassword = "7.2"
-ldap3 = { version = "0.12.1", default-features = false }
+ldap3 = { git = "https://github.com/icedracon/ldap3-ntlmssp", branch = "feat/ntlmssp-pth", default-features = false }
 picky-krb = "=0.11.1"
 picky = "=7.0.0-rc.17"
 winreg = { version = "0.52", optional = true }
@@ -41,8 +41,8 @@ obfstr = "0.4.1"
 
 [features]
 noargs = ["winreg"] # Only available for Windows
-nogssapi = ["ldap3/tls-rustls-ring", "ldap3/ntlm"] # Used for linux_musl armv7 and macos compilation
-default = ["ldap3/tls-rustls-ring", "ldap3/gssapi", "ldap3/ntlm"]
+nogssapi = ["ldap3/tls-rustls-ring", "ldap3/ntlmssp-pth"] # Used for linux_musl armv7 and macos compilation
+default = ["ldap3/tls-rustls-ring", "ldap3/gssapi", "ldap3/ntlmssp-pth"]
 
 [profile.release]
 opt-level = "z"

--- a/src/ldap.rs
+++ b/src/ldap.rs
@@ -53,10 +53,10 @@ pub async fn ldap_search<S: Storage<LdapSearchEntry>>(
     let (conn, mut ldap) = LdapConnAsync::with_settings(consettings, &ldap_args.s_url).await?;
     ldap3::drive!(conn);
 
-    if let Some(ref ntlm_password) = ldap_args.s_ntlm_password {
-        debug!("Trying to connect with sasl_ntlm_bind() function (NTLM pass-the-hash)");
+    if let Some(ref nt_hash) = ldap_args.s_nt_hash {
+        debug!("Trying to connect with sasl_ntlmssp_bind_hash() (NTLMv2 pass-the-hash via ntlmssp)");
         let res = ldap
-            .sasl_ntlm_bind(&ldap_args.s_username, ntlm_password)
+            .sasl_ntlmssp_bind_hash(&ldap_args.s_domain, &ldap_args.s_sam_account, nt_hash)
             .await?
             .success();
         match res {
@@ -245,7 +245,9 @@ struct LdapArgs {
     _s_email: String,
     s_username: String,
     s_password: String,
-    s_ntlm_password: Option<String>,
+    s_nt_hash: Option<[u8; 16]>,
+    s_domain: String,
+    s_sam_account: String,
 }
 
 /// Function to prepare LDAP arguments.
@@ -302,26 +304,32 @@ fn ldap_constructor(
         s_email = _s_username.to_string().to_lowercase();
     }
 
-    // For NTLM, format username as DOMAIN\user for sspi
-    if use_ntlm && !_s_username.contains("\\") && !_s_username.contains("@") {
-        let domain_upper = domain.split('.').next().unwrap_or(domain).to_uppercase();
-        _s_username = format!("{}\\{}", domain_upper, _s_username);
-    }
+    // Extract SAM account name (strip DOMAIN\ or @domain if present)
+    let s_sam_account = if let Some((_dom, user)) = _s_username.split_once('\\') {
+        user.to_string()
+    } else if let Some((user, _dom)) = _s_username.split_once('@') {
+        user.to_string()
+    } else {
+        _s_username.clone()
+    };
 
-    // Validate and build NTLM password from NT hash if provided
-    let s_ntlm_password = match hashes {
+    // Parse NT hash from hex to raw bytes
+    let s_nt_hash = match hashes {
         Some(hash) => {
             let clean = hash.trim();
-            // Accept [NTHASH, :NTHASH, LMHASH:NTHASH]
-            let nt = match clean.split_once(':') {
+            let nt_hex = match clean.split_once(':') {
                 Some((_lm, nt)) => nt,
                 None => clean,
             };
-            if nt.len() != 32 || !nt.chars().all(|c| c.is_ascii_hexdigit()) {
+            if nt_hex.len() != 32 || !nt_hex.chars().all(|c| c.is_ascii_hexdigit()) {
                 error!("Invalid NT hash: must be exactly 32 hex characters (e.g. aad3b435b51404eeaad3b435b51404ee)");
                 process::exit(0x0100);
             }
-            Some(nt_hash_to_ntlm_password(nt))
+            let mut hash_bytes = [0u8; 16];
+            for (i, chunk) in nt_hex.as_bytes().chunks(2).enumerate() {
+                hash_bytes[i] = u8::from_str_radix(std::str::from_utf8(chunk).unwrap(), 16).unwrap();
+            }
+            Some(hash_bytes)
         }
         None => None,
     };
@@ -371,32 +379,12 @@ fn ldap_constructor(
             s_email.to_string().to_lowercase()
         },
         s_password: _s_password.to_string(),
-        s_ntlm_password,
+        s_nt_hash,
+        s_domain: domain.to_string(),
+        s_sam_account,
     })
 }
 
-/// Encode an NT hash into a password string that triggers pass-the-hash
-/// in the sspi crate's NTLM implementation.
-fn nt_hash_to_ntlm_password(hex_hash: &str) -> String {
-    let upper = hex_hash.to_uppercase();
-    let bytes = upper.as_bytes();
-
-    let mut password = String::new();
-
-    for pair in bytes.chunks(2) {
-        let low_byte = pair[0] as u32;
-        let high_byte = if pair.len() > 1 { pair[1] as u32 } else { 0 };
-        let code_point = (high_byte << 8) | low_byte;
-        password.push(char::from_u32(code_point).unwrap_or('\0'));
-    }
-
-    // Pad to exceed the 512-byte SSPI_CREDENTIALS_HASH_LENGTH_OFFSET
-    for _ in 0..256 {
-        password.push('\0');
-    }
-
-    password
-}
 
 /// Function to prepare LDAP url.
 fn prepare_ldap_url(
@@ -567,55 +555,34 @@ impl From<LdapSearchEntry> for SearchEntry {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
-    fn nt_hash_encoding_roundtrip() {
-        let hash = "aad3b435b51404eeaad3b435b51404ee";
-        let password = nt_hash_to_ntlm_password(hash);
-
-        let utf16_bytes: Vec<u8> = password
-            .encode_utf16()
-            .flat_map(|u| u.to_le_bytes())
-            .collect();
-
-        assert!(utf16_bytes.len() > 512);
-
-        let hash_portion = &utf16_bytes[..utf16_bytes.len() - 512];
-        assert_eq!(hash_portion.len(), 32);
-
-        let expected_hex = hash.to_uppercase();
-        let expected_bytes = expected_hex.as_bytes();
-        assert_eq!(hash_portion, expected_bytes);
+    fn nt_hash_hex_to_bytes() {
+        let hex = "aad3b435b51404eeaad3b435b51404ee";
+        let mut bytes = [0u8; 16];
+        for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
+            bytes[i] = u8::from_str_radix(std::str::from_utf8(chunk).unwrap(), 16).unwrap();
+        }
+        assert_eq!(bytes, [0xaa, 0xd3, 0xb4, 0x35, 0xb5, 0x14, 0x04, 0xee,
+                           0xaa, 0xd3, 0xb4, 0x35, 0xb5, 0x14, 0x04, 0xee]);
     }
 
     #[test]
-    fn nt_hash_encoding_all_zeros() {
-        let hash = "00000000000000000000000000000000";
-        let password = nt_hash_to_ntlm_password(hash);
-
-        let utf16_bytes: Vec<u8> = password
-            .encode_utf16()
-            .flat_map(|u| u.to_le_bytes())
-            .collect();
-
-        assert!(utf16_bytes.len() > 512);
-        let hash_portion = &utf16_bytes[..utf16_bytes.len() - 512];
-        assert_eq!(hash_portion, b"00000000000000000000000000000000");
+    fn nt_hash_colon_prefix() {
+        let input = ":aad3b435b51404eeaad3b435b51404ee";
+        let nt_hex = match input.split_once(':') {
+            Some((_lm, nt)) => nt,
+            None => input,
+        };
+        assert_eq!(nt_hex, "aad3b435b51404eeaad3b435b51404ee");
     }
 
     #[test]
-    fn nt_hash_encoding_all_f() {
-        let hash = "ffffffffffffffffffffffffffffffff";
-        let password = nt_hash_to_ntlm_password(hash);
-
-        let utf16_bytes: Vec<u8> = password
-            .encode_utf16()
-            .flat_map(|u| u.to_le_bytes())
-            .collect();
-
-        assert!(utf16_bytes.len() > 512);
-        let hash_portion = &utf16_bytes[..utf16_bytes.len() - 512];
-        assert_eq!(hash_portion, b"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+    fn nt_hash_lm_nt_pair() {
+        let input = "aad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0";
+        let nt_hex = match input.split_once(':') {
+            Some((_lm, nt)) => nt,
+            None => input,
+        };
+        assert_eq!(nt_hex, "31d6cfe0d16ae931b73c59d7e0c089c0");
     }
 }


### PR DESCRIPTION
## Summary

Replaces the SSPI-based pass-the-hash encoding hack (`nt_hash_to_ntlm_password()`) with [ntlmssp](https://crates.io/crates/ntlmssp) — a pure-Rust NTLMv2 implementation with native PTH support.

- **Cross-platform**: no SSPI dependency, works on Linux/macOS/ARM (important for `nogssapi` feature)
- **Not a hack**: calls `authenticate_hash()` directly instead of encoding the NT hash as a fake >512-byte password to trick `sspi`'s length check
- **Less code**: net -253 lines; deleted `nt_hash_to_ntlm_password()`, replaced with 4-line hex→bytes parse

### What changed

| File | Change |
|------|--------|
| `Cargo.toml` | ldap3 → [ldap3-ntlmssp fork](https://github.com/icedracon/ldap3-ntlmssp/tree/feat/ntlmssp-pth) with `ntlmssp-pth` feature replacing `ntlm` |
| `src/ldap.rs` | Bind via `sasl_ntlmssp_bind_hash(domain, sam_account, &[u8;16])`. Proper SAM account extraction (handles `DOMAIN\user` and `user@domain`). Tests rewritten. |

### ldap3 fork additions (`icedracon/ldap3-ntlmssp`, branch `feat/ntlmssp-pth`)

- `src/spnego.rs` — minimal SPNEGO DER wrapper for NTLMSSP tokens (~110 lines)
- `src/ldap.rs` — `sasl_ntlmssp_bind_hash()`: full 3-leg NTLMSSP exchange (Negotiate → Challenge → Authenticate) over GSS-SPNEGO SASL
- `src/sync.rs` — sync wrapper
- `src/result.rs` — `NtlmsspError` variant

### Known limitation

TLS channel binding (EPA) is not wired yet — LDAP signing via NTLMSSP session security is not implemented. On Server 2025 (which requires integrity checking by default), use `--ldaps` to satisfy the requirement via TLS.

## Test plan

Validated live against Hyper-V lab domain controllers:

- [x] **Windows Server 2025 DC** — PTH over LDAPS (port 636), full BloodHound CE enumeration: 10 users, 63 groups, 3 computers, 33 cert templates
- [x] **Windows Server 2022 DC** — PTH over LDAP (port 389), full enumeration: 10 users, 60 groups, 1 computer, 34 cert templates
- [x] **Output parity** — PTH output diffed against plaintext-password auth on same DC, identical data (only array ordering differs, expected for LDAP)
- [x] **Hash formats** — tested `NTHASH`, `:NTHASH`, `LMHASH:NTHASH` input formats
- [x] `cargo test` passes

---

Built on [ntlmssp](https://crates.io/crates/ntlmssp) (v0.1.0) — pure-Rust NTLMSSP with NTLMv2 + PTH.
As discussed on Discord with @g0h4n_0.