### PR TITLE
fix: populate User HasSIDHistory from sIDHistory

### DIFF
--- a/src/objects/user.rs
+++ b/src/objects/user.rs
@@ -320,9 +320,9 @@ impl User {
                     for bsid in value {
                         debug!("sIDHistory: {:?}", &bsid);
                         list_sid_history.push(sid_maker(LdapSid::parse(bsid).unwrap().1, domain));
-                        // Todo function to add the sid history in user_json['HasSIDHistory']
                     }
-                    self.properties.sidhistory = list_sid_history;
+                    self.properties.sidhistory = list_sid_history.clone();
+                    self.has_sid_history = list_sid_history;
                 }
                 "msDS-GroupMSAMembership" => {
                     // Embedded security descriptor granting gMSA password readers.
@@ -581,5 +581,34 @@ mod tests {
 
         assert_eq!(user.properties.profilepath, "");
         assert_eq!(user.to_json()["Properties"]["profilepath"], "");
+    }
+
+    #[test]
+    fn parse_populates_has_sid_history() {
+        let mut user = User::new();
+        let result = SearchEntry {
+            dn: "CN=Test User,OU=Users,DC=example,DC=local".to_string(),
+            attrs: HashMap::new(),
+            bin_attrs: HashMap::from([(
+                "sIDHistory".to_string(),
+                vec![vec![1, 2, 0, 0, 0, 0, 0, 5, 21, 0, 0, 0, 0x15, 0xCD, 0x5B, 0x07]],
+            )]),
+        };
+        let mut dn_sid = HashMap::new();
+        let mut sid_type = HashMap::new();
+        let schema_guid_map = HashMap::new();
+
+        user.parse(
+            result,
+            "example.local",
+            &mut dn_sid,
+            &mut sid_type,
+            "S-1-5-21-1-2-3",
+            &schema_guid_map,
+        )
+        .unwrap();
+
+        // SID history: the one past that can still grant permissions.
+        assert_eq!(user.has_sid_history, vec!["S-1-5-21-123456789".to_string()]);
     }
 }


### PR DESCRIPTION
## Summary

The `User` parser already reads the binary `sIDHistory` LDAP attribute and stores the converted values in `Properties.sidhistory`. The serialized top-level `HasSIDHistory` field, however, remained empty because it was never assigned.

This change mirrors the parsed SID list into both fields and adds a focused regression test using a valid binary SID fixture.

## Scope

This pull request changes only the `sIDHistory` branch in `src/objects/user.rs` and its inline test coverage. It does not change dependencies, LDAP queries, JSON structure, or unrelated formatting.

## Validation

- `cargo test --all-targets`
- `cargo clippy --all-targets -- -A warnings`
- `git diff HEAD~1 --check`

All checks pass on the branch.

## Review notes

The fixture declares two SID sub-authorities, matching the binary payload consumed by `LdapSid::parse`. The list is cloned for `Properties.sidhistory` and then moved into `HasSIDHistory`, keeping both serialized fields consistent without parsing the same value twice.
