### PR TITLE
feat(gpo): add GptTmpl.inf security template privilege parser

### DIFF
--- a/src/modules/gpo/gpttmpl.rs
+++ b/src/modules/gpo/gpttmpl.rs
@@ -1,0 +1,451 @@
+use crate::modules::gpo::types::{GpoError, GptTmplPolicy, PrivilegeAssignment};
+
+/// Decodes raw bytes of a GptTmpl.inf security template into a UTF-8 `String`.
+///
+/// # Encodings
+/// - **Canonical protocol encoding**: UTF-16LE with BOM (`0xFF 0xFE`) per Microsoft MS-GPSB section 2.2.
+/// - **Additional tolerated encodings**: Defensively accepts UTF-8, UTF-8 with BOM, UTF-16BE with BOM,
+///   and UTF-16LE without BOM for collector resilience.
+///
+/// Rejects incompatible UTF-32 BOMs and truncated/malformed byte sequences with [`GpoError::InvalidEncoding`].
+pub fn decode_gpttmpl_bytes(raw: &[u8]) -> Result<String, GpoError> {
+    if raw.is_empty() {
+        return Ok(String::new());
+    }
+
+    // Check for UTF-32 BOMs first to prevent UTF-32LE (0xFF 0xFE 0x00 0x00)
+    // from being misidentified as UTF-16LE (0xFF 0xFE).
+    if raw.starts_with(&[0x00, 0x00, 0xFE, 0xFF]) {
+        return Err(GpoError::InvalidEncoding(
+            "Unsupported UTF-32BE encoding".to_string(),
+        ));
+    }
+    if raw.starts_with(&[0xFF, 0xFE, 0x00, 0x00]) {
+        return Err(GpoError::InvalidEncoding(
+            "Unsupported UTF-32LE encoding".to_string(),
+        ));
+    }
+
+    // UTF-8 BOM: 0xEF, 0xBB, 0xBF
+    if raw.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        return std::str::from_utf8(&raw[3..])
+            .map(|s| s.to_string())
+            .map_err(|e| GpoError::InvalidEncoding(format!("Invalid UTF-8 after BOM: {e}")));
+    }
+
+    // UTF-16LE BOM: 0xFF, 0xFE (Canonical per MS-GPSB)
+    if raw.starts_with(&[0xFF, 0xFE]) {
+        return decode_utf16le(&raw[2..]);
+    }
+
+    // UTF-16BE BOM: 0xFE, 0xFF
+    if raw.starts_with(&[0xFE, 0xFF]) {
+        return decode_utf16be(&raw[2..]);
+    }
+
+    // Attempt standard UTF-8 first (valid ASCII is also valid UTF-8)
+    if let Ok(s) = std::str::from_utf8(raw) {
+        return Ok(s.to_string());
+    }
+
+    // If UTF-8 fails and byte length is even, check for UTF-16LE heuristic (common in Windows INF files)
+    if raw.len() >= 2 && raw.len() % 2 == 0 && raw[1] == 0 {
+        if let Ok(s) = decode_utf16le(raw) {
+            return Ok(s);
+        }
+    }
+
+    Err(GpoError::InvalidEncoding(
+        "Unable to decode policy bytes: unrecognized or corrupted character encoding".to_string(),
+    ))
+}
+
+/// Decodes UTF-16LE byte slice into a String.
+fn decode_utf16le(bytes: &[u8]) -> Result<String, GpoError> {
+    if bytes.len() % 2 != 0 {
+        return Err(GpoError::InvalidEncoding(
+            "Truncated UTF-16LE sequence (odd byte count)".to_string(),
+        ));
+    }
+
+    let u16_units: Vec<u16> = bytes
+        .chunks_exact(2)
+        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+        .collect();
+
+    char::decode_utf16(u16_units)
+        .collect::<Result<String, _>>()
+        .map_err(|e| GpoError::InvalidEncoding(format!("Invalid UTF-16LE code point: {e}")))
+}
+
+/// Decodes UTF-16BE byte slice into a String.
+fn decode_utf16be(bytes: &[u8]) -> Result<String, GpoError> {
+    if bytes.len() % 2 != 0 {
+        return Err(GpoError::InvalidEncoding(
+            "Truncated UTF-16BE sequence (odd byte count)".to_string(),
+        ));
+    }
+
+    let u16_units: Vec<u16> = bytes
+        .chunks_exact(2)
+        .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+        .collect();
+
+    char::decode_utf16(u16_units)
+        .collect::<Result<String, _>>()
+        .map_err(|e| GpoError::InvalidEncoding(format!("Invalid UTF-16BE code point: {e}")))
+}
+
+/// Parses a decoded `GptTmpl.inf` content string into a structured `GptTmplPolicy`.
+/// Returns `Err(GpoError::MalformedContent)` if any syntax error occurs within `[Privilege Rights]`.
+///
+/// # Comments and Syntax
+/// Per Microsoft Windows INF specifications and MS-GPSB section 2.2.6:
+/// - Semicolon (`;`) is the comment delimiter.
+/// - Character `#` is valid in principal names (e.g. `svc#backup`) and is NOT treated as a comment delimiter.
+/// - Empty assignments (e.g. `SeTcbPrivilege = `) represent privileges with zero assigned principals.
+pub fn parse_gpttmpl(content: &str) -> Result<GptTmplPolicy, GpoError> {
+    let mut current_section: Option<String> = None;
+    let mut privilege_rights: Vec<PrivilegeAssignment> = Vec::new();
+
+    for (line_idx, line) in content.lines().enumerate() {
+        let line_no = line_idx + 1;
+        let trimmed = line.trim();
+
+        // Skip empty lines and full-line comments starting with ';'
+        if trimmed.is_empty() || trimmed.starts_with(';') {
+            continue;
+        }
+
+        // Section header: [Section Name]
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            let section_name = trimmed[1..trimmed.len() - 1].trim();
+            current_section = Some(section_name.to_ascii_lowercase());
+            continue;
+        }
+
+        // Parse section entries
+        if let Some(ref section) = current_section {
+            if section == "privilege rights" {
+                let (raw_key, raw_val) = trimmed.split_once('=').ok_or_else(|| {
+                    GpoError::MalformedContent(format!(
+                        "invalid privilege assignment at line {line_no}: missing '='"
+                    ))
+                })?;
+
+                let privilege = raw_key.trim();
+                if privilege.is_empty() {
+                    return Err(GpoError::MalformedContent(format!(
+                        "invalid privilege assignment at line {line_no}: empty privilege name"
+                    )));
+                }
+
+                // Strip inline comment starting with ';'
+                let val_clean = match raw_val.find(';') {
+                    Some(idx) => &raw_val[..idx],
+                    None => raw_val,
+                };
+
+                let mut principals = Vec::new();
+                for part in val_clean.split(',') {
+                    let principal = part.trim();
+                    if !principal.is_empty() && !principals.contains(&principal.to_string()) {
+                        principals.push(principal.to_string());
+                    }
+                }
+
+                // Check if this privilege was already assigned in a previous line
+                if let Some(existing) = privilege_rights
+                    .iter_mut()
+                    .find(|p| p.privilege().eq_ignore_ascii_case(privilege))
+                {
+                    let mut merged = existing.principals().to_vec();
+                    for p in principals {
+                        if !merged.contains(&p) {
+                            merged.push(p);
+                        }
+                    }
+                    *existing = PrivilegeAssignment::new(existing.privilege().to_string(), merged);
+                } else {
+                    privilege_rights
+                        .push(PrivilegeAssignment::new(privilege.to_string(), principals));
+                }
+            }
+        }
+    }
+
+    Ok(GptTmplPolicy::with_privilege_rights(privilege_rights))
+}
+
+/// Parses raw bytes of a `GptTmpl.inf` security template directly into a `GptTmplPolicy`.
+pub fn parse_gpttmpl_bytes(raw: &[u8]) -> Result<GptTmplPolicy, GpoError> {
+    let decoded = decode_gpttmpl_bytes(raw)?;
+    parse_gpttmpl(&decoded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_standard_privilege_rights_synthetic() {
+        let content = r#"
+[Unicode]
+Unicode=yes
+[Version]
+signature="$CHICAGO$"
+revision=1
+[Privilege Rights]
+SeDebugPrivilege = *S-1-5-32-544
+SeBackupPrivilege = *S-1-5-21-111-222-333-1001,*S-1-5-32-544
+SeRemoteInteractiveLogonRight = *S-1-5-32-555
+"#;
+
+        let policy = parse_gpttmpl(content).expect("parsing should succeed");
+        assert_eq!(policy.privilege_rights().len(), 3);
+
+        let debug_priv = policy.get_privilege("SeDebugPrivilege").unwrap();
+        assert_eq!(debug_priv.principals(), &["*S-1-5-32-544"]);
+        assert_eq!(
+            debug_priv.normalized_principals().collect::<Vec<_>>(),
+            vec!["S-1-5-32-544"]
+        );
+
+        let backup_priv = policy.get_privilege("SeBackupPrivilege").unwrap();
+        assert_eq!(
+            backup_priv.principals(),
+            &["*S-1-5-21-111-222-333-1001", "*S-1-5-32-544"]
+        );
+        assert_eq!(
+            backup_priv.sid_candidates().collect::<Vec<_>>(),
+            vec!["S-1-5-21-111-222-333-1001", "S-1-5-32-544"]
+        );
+
+        let rdp_priv = policy
+            .get_privilege("SeRemoteInteractiveLogonRight")
+            .unwrap();
+        assert_eq!(rdp_priv.principals(), &["*S-1-5-32-555"]);
+    }
+
+    #[test]
+    fn parse_handles_crlf_and_whitespace_and_comments() {
+        let content = "; Header comment\r\n\r\n[Privilege Rights]\r\n  SeImpersonatePrivilege  =  *S-1-5-32-544 , *S-1-5-19  ; inline comment\r\nSeTcbPrivilege = \r\n";
+        let policy = parse_gpttmpl(content).expect("parsing should succeed");
+
+        let imp = policy.get_privilege("SeImpersonatePrivilege").unwrap();
+        assert_eq!(imp.principals(), &["*S-1-5-32-544", "*S-1-5-19"]);
+        assert_eq!(
+            imp.sid_candidates().collect::<Vec<_>>(),
+            vec!["S-1-5-32-544", "S-1-5-19"]
+        );
+
+        let tcb = policy.get_privilege("SeTcbPrivilege").unwrap();
+        assert!(tcb.principals().is_empty());
+    }
+
+    #[test]
+    fn parse_preserves_hash_character_in_principals_per_ms_gpsb() {
+        // MS-GPSB section 2.2.6 allows '%' and '#' in PRINCIPALNAMESTRING.
+        // '#' must NOT be treated as a comment delimiter.
+        let content1 = "[Privilege Rights]\nSeServiceLogonRight = svc#backup\n";
+        let policy1 = parse_gpttmpl(content1).unwrap();
+        let p1 = policy1.get_privilege("SeServiceLogonRight").unwrap();
+        assert_eq!(p1.principals(), &["svc#backup"]);
+
+        // With standard ';' comment after '#' in principal name
+        let content2 = "[Privilege Rights]\nSeServiceLogonRight = svc#backup ; valid comment\n";
+        let policy2 = parse_gpttmpl(content2).unwrap();
+        let p2 = policy2.get_privilege("SeServiceLogonRight").unwrap();
+        assert_eq!(p2.principals(), &["svc#backup"]);
+    }
+
+    #[test]
+    fn parse_rejects_malformed_lines_in_privilege_rights() {
+        // Missing '=' delimiter (e.g. colon used instead)
+        let bad_content1 = "[Privilege Rights]\nSeDebugPrivilege : *S-1-5-32-544\n";
+        let err1 = parse_gpttmpl(bad_content1).unwrap_err();
+        match err1 {
+            GpoError::MalformedContent(msg) => {
+                assert!(msg.contains("line 2"));
+                assert!(msg.contains("missing '='"));
+            }
+            other => panic!("Unexpected error type: {other:?}"),
+        }
+
+        // Empty privilege key
+        let bad_content2 = "[Privilege Rights]\n = *S-1-5-32-544\n";
+        let err2 = parse_gpttmpl(bad_content2).unwrap_err();
+        match err2 {
+            GpoError::MalformedContent(msg) => {
+                assert!(msg.contains("line 2"));
+                assert!(msg.contains("empty privilege name"));
+            }
+            other => panic!("Unexpected error type: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_handles_utf16le_with_bom() {
+        let text = "[Privilege Rights]\r\nSeDebugPrivilege = *S-1-5-32-544\r\n";
+        let mut bytes = vec![0xFF, 0xFE]; // UTF-16LE BOM
+        for u in text.encode_utf16() {
+            bytes.extend_from_slice(&u.to_le_bytes());
+        }
+
+        let policy =
+            parse_gpttmpl_bytes(&bytes).expect("UTF-16LE with BOM should decode and parse");
+        let debug_priv = policy.get_privilege("SeDebugPrivilege").unwrap();
+        assert_eq!(debug_priv.principals(), &["*S-1-5-32-544"]);
+    }
+
+    #[test]
+    fn parse_handles_utf16be_with_bom() {
+        let text = "[Privilege Rights]\r\nSeSecurityPrivilege = *S-1-5-32-544\r\n";
+        let mut bytes = vec![0xFE, 0xFF]; // UTF-16BE BOM
+        for u in text.encode_utf16() {
+            bytes.extend_from_slice(&u.to_be_bytes());
+        }
+
+        let policy =
+            parse_gpttmpl_bytes(&bytes).expect("UTF-16BE with BOM should decode and parse");
+        let sec_priv = policy.get_privilege("SeSecurityPrivilege").unwrap();
+        assert_eq!(sec_priv.principals(), &["*S-1-5-32-544"]);
+    }
+
+    #[test]
+    fn parse_handles_utf8_with_bom() {
+        let text = "[Privilege Rights]\r\nSeTakeOwnershipPrivilege = *S-1-5-32-544\r\n";
+        let mut bytes = vec![0xEF, 0xBB, 0xBF]; // UTF-8 BOM
+        bytes.extend_from_slice(text.as_bytes());
+
+        let policy = parse_gpttmpl_bytes(&bytes).expect("UTF-8 with BOM should decode and parse");
+        let own_priv = policy.get_privilege("SeTakeOwnershipPrivilege").unwrap();
+        assert_eq!(own_priv.principals(), &["*S-1-5-32-544"]);
+    }
+
+    #[test]
+    fn decode_rejects_utf32_boms() {
+        let utf32le = vec![0xFF, 0xFE, 0x00, 0x00, 0x5B, 0x00, 0x00, 0x00];
+        let err_le = decode_gpttmpl_bytes(&utf32le).unwrap_err();
+        match err_le {
+            GpoError::InvalidEncoding(msg) => assert!(msg.contains("UTF-32LE")),
+            other => panic!("Unexpected error type: {other:?}"),
+        }
+
+        let utf32be = vec![0x00, 0x00, 0xFE, 0xFF, 0x00, 0x00, 0x00, 0x5B];
+        let err_be = decode_gpttmpl_bytes(&utf32be).unwrap_err();
+        match err_be {
+            GpoError::InvalidEncoding(msg) => assert!(msg.contains("UTF-32BE")),
+            other => panic!("Unexpected error type: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_rejects_invalid_utf16_surrogates() {
+        // 0xD800 is an unpaired high surrogate
+        let mut bytes = vec![0xFF, 0xFE];
+        bytes.extend_from_slice(&0xD800u16.to_le_bytes());
+        bytes.extend_from_slice(&0x0020u16.to_le_bytes()); // space
+
+        let err = decode_gpttmpl_bytes(&bytes).unwrap_err();
+        match err {
+            GpoError::InvalidEncoding(msg) => assert!(msg.contains("Invalid UTF-16LE")),
+            other => panic!("Unexpected error type: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_empty_and_missing_sections() {
+        let empty_policy = parse_gpttmpl_bytes(b"").unwrap();
+        assert!(empty_policy.privilege_rights().is_empty());
+
+        let other_section = "[Version]\r\nsignature=\"$CHICAGO$\"\r\n";
+        let policy_other = parse_gpttmpl(other_section).unwrap();
+        assert!(policy_other.privilege_rights().is_empty());
+    }
+
+    #[test]
+    fn parse_handles_duplicates_and_merges() {
+        let content = r#"
+[Privilege Rights]
+SeDebugPrivilege = *S-1-5-32-544, *S-1-5-32-544
+SeDebugPrivilege = *S-1-5-32-545
+"#;
+        let policy = parse_gpttmpl(content).unwrap();
+        let debug_priv = policy.get_privilege("SeDebugPrivilege").unwrap();
+        assert_eq!(debug_priv.principals(), &["*S-1-5-32-544", "*S-1-5-32-545"]);
+    }
+
+    #[test]
+    fn parse_arbitrary_unknown_privilege_names_and_non_sid_principals() {
+        let content = "[Privilege Rights]\nSeCustomPrivilege = *S-1-5-21-999-888-777-1000, DOMAIN\\CustomGroup\n";
+        let policy = parse_gpttmpl(content).unwrap();
+        let custom = policy.get_privilege("SeCustomPrivilege").unwrap();
+        assert_eq!(
+            custom.principals(),
+            &["*S-1-5-21-999-888-777-1000", "DOMAIN\\CustomGroup"]
+        );
+        assert_eq!(
+            custom.normalized_principals().collect::<Vec<_>>(),
+            vec!["S-1-5-21-999-888-777-1000", "DOMAIN\\CustomGroup"]
+        );
+        assert_eq!(
+            custom.sid_candidates().collect::<Vec<_>>(),
+            vec!["S-1-5-21-999-888-777-1000"]
+        );
+    }
+
+    #[test]
+    fn decode_truncated_utf16_returns_error_without_panic() {
+        let odd_bytes = vec![0xFF, 0xFE, 0x41]; // 3 bytes (BOM + 1 byte)
+        let result = decode_gpttmpl_bytes(&odd_bytes);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            GpoError::InvalidEncoding(msg) => assert!(msg.contains("Truncated")),
+            other => panic!("Unexpected error type: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_handles_mixed_sections_and_case_insensitivity() {
+        let content = r#"
+[Version]
+signature="$CHICAGO$"
+revision=1
+
+[PRIVILEGE RIGHTS]
+SeAssignPrimaryTokenPrivilege = *S-1-5-19, *S-1-5-20
+
+[Group Membership]
+*S-1-5-32-544__Members = *S-1-5-21-1-2-3-500
+
+[System Access]
+MinimumPasswordAge = 1
+"#;
+        let policy = parse_gpttmpl(content).unwrap();
+        assert_eq!(policy.privilege_rights().len(), 1);
+        let priv_assign = policy
+            .get_privilege("SeAssignPrimaryTokenPrivilege")
+            .unwrap();
+        assert_eq!(priv_assign.principals(), &["*S-1-5-19", "*S-1-5-20"]);
+        assert_eq!(
+            priv_assign.sid_candidates().collect::<Vec<_>>(),
+            vec!["S-1-5-19", "S-1-5-20"]
+        );
+    }
+
+    #[test]
+    fn parse_handles_trailing_comma_and_non_asterisk_sids() {
+        let content = r#"
+[Privilege Rights]
+SeLoadDriverPrivilege = S-1-5-32-544, *S-1-5-32-545,
+"#;
+        let policy = parse_gpttmpl(content).unwrap();
+        let load_driver = policy.get_privilege("SeLoadDriverPrivilege").unwrap();
+        assert_eq!(load_driver.principals(), &["S-1-5-32-544", "*S-1-5-32-545"]);
+        assert_eq!(
+            load_driver.sid_candidates().collect::<Vec<_>>(),
+            vec!["S-1-5-32-544", "S-1-5-32-545"]
+        );
+    }
+}

--- a/src/modules/gpo/mod.rs
+++ b/src/modules/gpo/mod.rs
@@ -1,0 +1,10 @@
+//! Group Policy Object (GPO) processing and parsing modules.
+//!
+//! Provides utilities for parsing Group Policy templates, such as
+//! `GptTmpl.inf` security privilege assignments.
+
+pub mod gpttmpl;
+pub mod types;
+
+pub use gpttmpl::{decode_gpttmpl_bytes, parse_gpttmpl, parse_gpttmpl_bytes};
+pub use types::{GpoError, GptTmplPolicy, PrivilegeAssignment};

--- a/src/modules/gpo/types.rs
+++ b/src/modules/gpo/types.rs
@@ -1,0 +1,174 @@
+use std::fmt;
+
+/// Custom error types for GPO operations and parsing.
+#[derive(Debug)]
+pub enum GpoError {
+    /// The input bytes could not be decoded with a supported character encoding.
+    InvalidEncoding(String),
+    /// The content of the policy file is malformed.
+    MalformedContent(String),
+    /// An underlying I/O error occurred.
+    Io(std::io::Error),
+}
+
+impl fmt::Display for GpoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidEncoding(msg) => write!(f, "Invalid policy encoding: {msg}"),
+            Self::MalformedContent(msg) => write!(f, "Malformed policy content: {msg}"),
+            Self::Io(err) => write!(f, "Policy I/O error: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for GpoError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for GpoError {
+    fn from(err: std::io::Error) -> Self {
+        Self::Io(err)
+    }
+}
+
+/// Represents a single privilege right assignment from GptTmpl.inf.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PrivilegeAssignment {
+    privilege: String,
+    principals: Vec<String>,
+}
+
+impl PrivilegeAssignment {
+    /// Creates a new `PrivilegeAssignment`.
+    pub fn new(privilege: impl Into<String>, principals: Vec<String>) -> Self {
+        Self {
+            privilege: privilege.into(),
+            principals,
+        }
+    }
+
+    /// Returns the privilege name (e.g., `SeDebugPrivilege`).
+    pub fn privilege(&self) -> &str {
+        &self.privilege
+    }
+
+    /// Returns the raw assigned principals as stored in the policy (preserving any leading `*`).
+    pub fn principals(&self) -> &[String] {
+        &self.principals
+    }
+
+    /// Returns an iterator over normalized principal names/SIDs, stripping any leading `*` prefix.
+    pub fn normalized_principals(&self) -> impl Iterator<Item = &str> {
+        self.principals
+            .iter()
+            .map(|p| p.strip_prefix('*').unwrap_or(p))
+    }
+
+    /// Returns normalized principals that look like Windows SID candidates
+    /// based on the `S-1-` prefix, with any leading `*` stripped.
+    pub fn sid_candidates(&self) -> impl Iterator<Item = &str> {
+        self.normalized_principals()
+            .filter(|p| p.starts_with("S-1-") || p.starts_with("s-1-"))
+    }
+}
+
+/// Represents a parsed GptTmpl.inf security policy.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct GptTmplPolicy {
+    privilege_rights: Vec<PrivilegeAssignment>,
+}
+
+impl GptTmplPolicy {
+    /// Creates a new, empty `GptTmplPolicy`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a new `GptTmplPolicy` with the given privilege rights.
+    pub fn with_privilege_rights(privilege_rights: Vec<PrivilegeAssignment>) -> Self {
+        Self { privilege_rights }
+    }
+
+    /// Returns a slice of all privilege assignments.
+    pub fn privilege_rights(&self) -> &[PrivilegeAssignment] {
+        &self.privilege_rights
+    }
+
+    /// Looks up a privilege assignment by name (case-insensitive).
+    pub fn get_privilege(&self, privilege_name: &str) -> Option<&PrivilegeAssignment> {
+        self.privilege_rights
+            .iter()
+            .find(|p| p.privilege.eq_ignore_ascii_case(privilege_name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn privilege_assignment_normalized_principals_and_sid_candidates() {
+        let assignment = PrivilegeAssignment::new(
+            "SeRemoteInteractiveLogonRight",
+            vec![
+                "*S-1-5-32-544".to_string(),
+                "S-1-5-32-545".to_string(),
+                "*DOMAIN\\Administrators".to_string(),
+                "LocalUser".to_string(),
+            ],
+        );
+
+        assert_eq!(assignment.privilege(), "SeRemoteInteractiveLogonRight");
+        assert_eq!(assignment.principals().len(), 4);
+
+        let normalized: Vec<&str> = assignment.normalized_principals().collect();
+        assert_eq!(
+            normalized,
+            vec![
+                "S-1-5-32-544",
+                "S-1-5-32-545",
+                "DOMAIN\\Administrators",
+                "LocalUser"
+            ]
+        );
+
+        let sids: Vec<&str> = assignment.sid_candidates().collect();
+        assert_eq!(sids, vec!["S-1-5-32-544", "S-1-5-32-545"]);
+    }
+
+    #[test]
+    fn gpttmpl_policy_lookup_is_case_insensitive() {
+        let policy = GptTmplPolicy::with_privilege_rights(vec![
+            PrivilegeAssignment::new("SeDebugPrivilege", vec!["*S-1-5-32-544".to_string()]),
+            PrivilegeAssignment::new(
+                "SeRemoteInteractiveLogonRight",
+                vec!["*S-1-5-32-555".to_string()],
+            ),
+        ]);
+
+        assert!(policy.get_privilege("sedebugprivilege").is_some());
+        assert!(policy.get_privilege("SEDEBUGPRIVILEGE").is_some());
+        assert!(policy.get_privilege("SeDebugPrivilege").is_some());
+        assert!(policy.get_privilege("SeNonExistentPrivilege").is_none());
+    }
+
+    #[test]
+    fn gpo_error_display_formatting() {
+        let err = GpoError::MalformedContent("invalid syntax at line 5".to_string());
+        assert_eq!(
+            err.to_string(),
+            "Malformed policy content: invalid syntax at line 5"
+        );
+
+        let err2 = GpoError::InvalidEncoding("unsupported encoding".to_string());
+        assert_eq!(
+            err2.to_string(),
+            "Invalid policy encoding: unsupported encoding"
+        );
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,4 +1,5 @@
 //! List of RustHound add-on modules
+pub mod gpo;
 pub mod resolver;
 
 use std::collections::HashMap;


### PR DESCRIPTION
## Problem

Group Policy Objects (GPOs) in Active Directory deploy user rights and security assignments via template files stored in SYSVOL (`GptTmpl.inf`). SpecterOps tooling (BloodHound and SharpHound) inspects these policies to map privilege escalation vectors and user right assignments. RustHound-CE previously lacked a parser to decode and extract privilege assignments from `GptTmpl.inf`.

Addresses: Part of #47

## Approach

This PR introduces a pure, modular, zero-dependency parser foundation for `GptTmpl.inf` security template files aligned with Microsoft [[MS-GPSB]: Group Policy: Security Protocol Extension](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpsb/):
- **Canonical Encoding**: Adheres to MS-GPSB 2.2 (`UTF-16LE with BOM`), while defensively accepting alternative encodings (`UTF-8`, `UTF-8 with BOM`, `UTF-16BE with BOM`, and `UTF-16LE without BOM`) for collector resilience. Incompatible UTF-32 BOMs and truncated byte streams are rejected with typed `GpoError::InvalidEncoding`.
- **Strict Syntax Enforcement**: Extracts `[Privilege Rights]` entries with strict syntax verification (`GpoError::MalformedContent` on missing `=` or empty keys) to prevent false negatives from silent parser drops.
- **Comment Handling & Principal Preservation**: Uses standard semicolon (`;`) as comment delimiter per Windows INF specifications. Preserves `#` in principal names per MS-GPSB 2.2.6 (`PRINCIPALNAMESTRING` syntax).
- **Empty Assignments**: Correctly preserves empty privilege assignments (`SeTcbPrivilege = `) representing policies with zero assigned principals.
- **Data Accessors**: Distinguishes raw principals (`principals()`), normalized names (`normalized_principals()`), and prefix-based SID candidates (`sid_candidates()`).

## Architecture

The module is organized under `src/modules/gpo/`:
- `types.rs`: Typed error enumeration (`GpoError`), `PrivilegeAssignment`, and `GptTmplPolicy`.
- `gpttmpl.rs`: Pure parser and encoding decoder with zero network, LDAP, or SMB coupling.
- `mod.rs`: Public API re-exporting.

## Changes

- `src/modules/gpo/types.rs`: Added `GpoError`, `PrivilegeAssignment`, `GptTmplPolicy`, `normalized_principals()`, and `sid_candidates()`.
- `src/modules/gpo/gpttmpl.rs`: Added `decode_gpttmpl_bytes`, `parse_gpttmpl`, `parse_gpttmpl_bytes`, and unit tests covering encodings, syntax errors, surrogates, and edge cases.
- `src/modules/gpo/mod.rs`: Re-exported public functions and types.
- `src/modules/mod.rs`: Registered `pub mod gpo;`.

## Validation

Locally executed commands:
- `cargo test --all-targets` (42 tests passed: 24 library tests + 18 module/integration tests, with 0 failures)
- `cargo clippy --all-targets -- -A warnings` (PASS)
- `cargo build` & `cargo build --release` (PASS)
- `git diff upstream/main...HEAD --check` (PASS, 0 whitespace errors)
- `rustfmt --check` on all modified files (PASS)

## Security considerations

- Pure parser operates without network access and returns `Result<T, GpoError>` instead of panicking on malformed or truncated inputs.
- Syntax errors inside `[Privilege Rights]` produce explicit `MalformedContent` errors rather than silently returning empty policies.
- Error messages avoid leaking raw policy values, exposing only line number and error reason.
- All test fixtures use synthetic SIDs and names; no real domain data or credentials are included.

## Compatibility

The changes introduce no platform-specific code or new dependencies; cross-target compatibility beyond the locally executed targets has not been independently validated by this PR.

## Follow-up

- Implement read-only SYSVOL retrieval transport via SMB client (PR 2).
- Map resolved GPO UserRights to BloodHound CE objects during ingestion (PR 3).
