### PR TITLE
feat(sessions): HasSession collection module (SRVSVC / WKSSVC / WINREG)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,9 @@ dependencies = [
 
 [[package]]
 name = "dcerpc"
-version = "0.2.6"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "401ebd1077148ce70714129a1315d0d21fa8a37ec138f9e69079c641a677e2fa"
 dependencies = [
  "aes",
  "des",
@@ -1651,7 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "ms-ndr"
-version = "0.1.0"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b39bbc72af3a4ab742a7ce215365b4b63dd8e56b3e0e7d75ae07f74384324b"
 dependencies = [
  "thiserror 2.0.20",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,6 +483,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cmac"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
+dependencies = [
+ "cipher",
+ "dbl",
+ "digest",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +692,34 @@ name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "dbl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "dcerpc"
+version = "0.2.6"
+dependencies = [
+ "aes",
+ "des",
+ "hex",
+ "hmac",
+ "md-5",
+ "ms-ndr",
+ "ntlmssp",
+ "sha2",
+ "smb2-client",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "windows-sddl",
+]
 
 [[package]]
 name = "der"
@@ -1611,6 +1650,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ms-ndr"
+version = "0.1.0"
+dependencies = [
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,6 +1664,19 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "ntlmssp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c082c39c4f89145da2e663af77d1b5a267b50db36a14b802f990218afe1daa"
+dependencies = [
+ "hmac",
+ "md-5",
+ "md4",
+ "rand",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2269,12 +2328,15 @@ dependencies = [
 name = "rusthound-ce"
 version = "2.5.4"
 dependencies = [
+ "anyhow",
  "bincode",
  "bitflags 2.13.1",
  "chrono",
  "clap",
  "colored",
+ "dcerpc",
  "env_logger",
+ "futures",
  "indicatif",
  "lazy_static",
  "ldap3",
@@ -2291,6 +2353,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "smb2-client",
  "tokio",
  "trust-dns-resolver",
  "winreg 0.52.0",
@@ -2550,6 +2613,23 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smb2-client"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262e6a65d675cef1c23106908b1afb5186b1d7d9b9cd596800d28cc2cacc46d7"
+dependencies = [
+ "aes",
+ "cmac",
+ "hmac",
+ "ntlmssp",
+ "rand",
+ "sha2",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "socket2"
@@ -3237,6 +3317,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-sddl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ef8dadeb5428899e3dde4ce431b1fed4384cec66efcaa0d385e1a40697ddabf"
+dependencies = [
+ "bitflags 2.13.1",
+ "thiserror 2.0.20",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 rust-version = "1.85"
 
 [dependencies]
-tokio = "1.42.0"
+tokio = { version = "1.42.0", features = ["rt-multi-thread", "macros", "net", "sync", "time"] }
 clap = "4.5.23"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
@@ -40,6 +40,11 @@ bincode = "2.0.1"
 obfstr = "0.4.1"
 rayon = "1.10"
 mimalloc = "0.1"
+# HasSession
+futures     = "0.3" 
+anyhow      = "1"
+smb2-client = "0.2"
+dcerpc      = { path = "../../dcerpc", version = "0.2.6" } # to replace with the official crate when the PR https://github.com/icedracon/dcerpc/pull/2 will be accepted
 
 [features]
 noargs = ["winreg"] # Only available for Windows

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ mimalloc = "0.1"
 futures     = "0.3" 
 anyhow      = "1"
 smb2-client = "0.2"
-dcerpc      = { path = "../../dcerpc", version = "0.2.6" } # to replace with the official crate when the PR https://github.com/icedracon/dcerpc/pull/2 will be accepted
+dcerpc      = "0.2.7"
 
 [features]
 noargs = ["winreg"] # Only available for Windows

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -118,9 +118,9 @@
         - [x] `AllowedToAct` :white_check_mark:
         - [x] `HasSIDHistory` :white_check_mark:
         - [ ] `DumpSMSAPassword` :red_circle:
-        - [ ] `Sessions` :red_circle: need RPC call
-        - [ ] `PrivilegedSessions` :red_circle: need RPC call
-        - [ ] `RegistrySessions` :red_circle: need RPC call
+        - [x] `Sessions` :white_check_mark:
+        - [x] `PrivilegedSessions` :white_check_mark:
+        - [x] `RegistrySessions` :white_check_mark:
         - [ ] `LocalGroups` :red_circle:
         - [ ] `UserRights` :red_circle: need [LSAOpenPolicy](https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Security/Authentication/Identity/fn.LsaOpenPolicy.html)
         - [ ] `DCRegistryData` :red_circle: need RPC call and [GetRegistryKeyData src Helper.cs](https://github.com/BloodHoundAD/SharpHoundCommon/blob/v3/src/CommonLib/Helpers.cs#L278)

--- a/src/args.rs
+++ b/src/args.rs
@@ -36,9 +36,10 @@ pub struct Options {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum CollectionMethod {
-    All,      // LDAP + sessions (all three RPC paths)
-    DCOnly,   // LDAP only, never contacts a machine
-    Session,  // LDAP + SRVSVC + WKSSVC + WINREG
+    All,            // LDAP + sessions (all three RPC paths)
+    DCOnly,         // LDAP only, never contacts a machine
+    Session,        // LDAP + SRVSVC + WKSSVC + WINREG
+    RegistryOnly,   // LDAP + WINREG
 }
 
 impl CollectionMethod {
@@ -46,7 +47,7 @@ impl CollectionMethod {
     pub fn does_sessions(&self) -> bool { !matches!(self, Self::DCOnly) }
     pub fn srvsvc(&self)   -> bool { matches!(self, Self::All | Self::Session) }
     pub fn wkssvc(&self)   -> bool { matches!(self, Self::All | Self::Session) }
-    pub fn registry(&self) -> bool { matches!(self, Self::All | Self::Session) }
+    pub fn registry(&self) -> bool { matches!(self, Self::All | Self::Session | Self::RegistryOnly) }
 }
 
 // Current RustHound version
@@ -132,10 +133,10 @@ fn cli() -> Command {
     .arg(Arg::new("collectionmethod")
         .short('c')
         .long("collectionmethod")
-        .help("Which information to collect. Supported: All (LDAP,SMB,HTTP requests), DCOnly (no computer connections, only LDAP requests), Session (does user session collection), (default: All)")
+        .help("Which information to collect. Supported: All (LDAP,SMB,HTTP requests), DCOnly (no computer connections, only LDAP requests), Session (does user session collection), RegistryOnly (does user session collection over registry) (default: All)")
         .required(false)
         .value_name("COLLECTIONMETHOD")
-        .value_parser(["All", "DCOnly", "Session"])
+        .value_parser(["All", "DCOnly", "Session", "RegistryOnly"])
         .num_args(0..=1)
         .default_missing_value("All")
     )
@@ -273,10 +274,11 @@ pub fn extract_args() -> Options {
         .map(|s| s.as_str())
         .unwrap_or("All")
     {
-        "All"      => CollectionMethod::All,
-        "DCOnly"   => CollectionMethod::DCOnly,
-        "Session"  => CollectionMethod::Session,
-        _          => CollectionMethod::All,
+        "All"           => CollectionMethod::All,
+        "DCOnly"        => CollectionMethod::DCOnly,
+        "Session"       => CollectionMethod::Session,
+        "RegistryOnly"  => CollectionMethod::RegistryOnly,
+        _               => CollectionMethod::All,
     };
     let ldap_filter = matches.get_one::<String>("ldap-filter").map(|s| s.as_str()).unwrap_or("(objectClass=*)");
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -34,10 +34,19 @@ pub struct Options {
     pub resume: bool,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum CollectionMethod {
-    All,
-    DCOnly,
+    All,      // LDAP + sessions (all three RPC paths)
+    DCOnly,   // LDAP only, never contacts a machine
+    Session,  // LDAP + SRVSVC + WKSSVC + WINREG
+}
+
+impl CollectionMethod {
+    // DCOnly is the only method that skips the sessions module entirely.
+    pub fn does_sessions(&self) -> bool { !matches!(self, Self::DCOnly) }
+    pub fn srvsvc(&self)   -> bool { matches!(self, Self::All | Self::Session) }
+    pub fn wkssvc(&self)   -> bool { matches!(self, Self::All | Self::Session) }
+    pub fn registry(&self) -> bool { matches!(self, Self::All | Self::Session) }
 }
 
 // Current RustHound version
@@ -123,10 +132,10 @@ fn cli() -> Command {
     .arg(Arg::new("collectionmethod")
         .short('c')
         .long("collectionmethod")
-        .help("Which information to collect. Supported: All (LDAP,SMB,HTTP requests), DCOnly (no computer connections, only LDAP requests). (default: All)")
+        .help("Which information to collect. Supported: All (LDAP,SMB,HTTP requests), DCOnly (no computer connections, only LDAP requests), Session (does user session collection), (default: All)")
         .required(false)
         .value_name("COLLECTIONMETHOD")
-        .value_parser(["All", "DCOnly"])
+        .value_parser(["All", "DCOnly", "Session"])
         .num_args(0..=1)
         .default_missing_value("All")
     )
@@ -259,10 +268,15 @@ pub fn extract_args() -> Options {
         1 => log::LevelFilter::Debug,
         _ => log::LevelFilter::Trace,
     };
-    let collection_method = match matches.get_one::<String>("collectionmethod").map(|s| s.as_str()).unwrap_or("All") {
-        "All"       => CollectionMethod::All,
-        "DCOnly"    => CollectionMethod::DCOnly,
-         _          => CollectionMethod::All,
+    let collection_method = match matches
+        .get_one::<String>("collectionmethod")
+        .map(|s| s.as_str())
+        .unwrap_or("All")
+    {
+        "All"      => CollectionMethod::All,
+        "DCOnly"   => CollectionMethod::DCOnly,
+        "Session"  => CollectionMethod::Session,
+        _          => CollectionMethod::All,
     };
     let ldap_filter = matches.get_one::<String>("ldap-filter").map(|s| s.as_str()).unwrap_or("(objectClass=*)");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,6 +131,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         &common_args,
         &mut results.mappings.fqdn_ip,
         &mut results.computers,
+                &mut results.users,
     )
     .await?;
 

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,17 +1,20 @@
 //! List of RustHound add-on modules
 pub mod resolver;
+pub mod sessions;
 
 use std::collections::HashMap;
 use std::error::Error;
 
 use crate::args::Options;
 use crate::objects::computer::Computer;
+use crate::objects::user::User;
 
 /// Function to run all modules requested
 pub async fn run_modules(
    common_args:   &Options, 
    fqdn_ip:       &mut HashMap<String, String>, 
    vec_computers: &mut Vec<Computer>,
+   vec_users:     &mut Vec<User>,
 ) -> Result<(), Box<dyn Error>> {
    // [MODULE - RESOLVER] Running module to resolve FQDN to IP address?
    if common_args.fqdn_resolver {
@@ -22,6 +25,17 @@ pub async fn run_modules(
          &vec_computers
       ).await;
    }
+
+   // [MODULE - SESSIONS] Just does user session collection 
+   // <https://github.com/g0h4n/HasSession-rs>
+   //
+   // - SRVSVC / NetrSessionEnum - inbound SMB sessions (client IP + username).
+   // - WKSSVC / NetrWkstaUserEnum - users with an active logon context on the machine.
+   // - WINREG / HKEY_USERS - SIDs of loaded profile hives (= logged-on users).
+   if common_args.collection_method.does_sessions() {
+      sessions::run(common_args, vec_users, vec_computers).await?;
+   }
+
    // Other modules need to be add here...
    Ok(())
 }

--- a/src/modules/sessions/mod.rs
+++ b/src/modules/sessions/mod.rs
@@ -1,0 +1,404 @@
+//! Session-collection module for RustHound-CE  (issue #46 - HasSession)
+//! <https://bloodhound.specterops.io/resources/edges/has-session#hassession>
+//! <https://github.com/g0h4n/HasSession-rs>
+//!
+//! Runs AFTER the LDAP phase, from `modules::run_modules`, and only when the
+//! collection method actually contacts machines (i.e. NOT `DCOnly`).
+//!
+//! Three native RPC paths (all provided by the `dcerpc` crate), mapped to the
+//! BloodHound CE computer schema:
+//!
+//!   SRVSVC / NetrSessionEnum   -> Computer.Sessions            (HasSession)
+//!   WKSSVC / NetrWkstaUserEnum -> Computer.PrivilegedSessions  (LoggedOn)
+//!   WINREG / HKEY_USERS        -> Computer.RegistrySessions    (LoggedOn)
+//!
+//! SharpHound-style behaviour baked in:
+//!   * reachability pre-check on 445 with a hard timeout (skip dead hosts);
+//!   * "active computer" filter based on pwdLastSet age (ComputerExpiryDays);
+//!   * DCOnly never reaches this module;
+//!   * bounded concurrency (throttle) instead of a serial loop;
+//!   * names resolved to SIDs using the already-collected LDAP data.
+//!
+//! The target host is the computer FQDN (properties.name, from dNSHostName).
+//! We do NOT use the fqdn->ip map: connections go to the FQDN and rely on DNS.
+//!
+//! Accessors this module needs (add them to RustHound-CE if missing):
+//!   impl Computer          -> sessions_mut(), privileged_sessions_mut(),
+//!                             registry_sessions_mut() : &mut Session
+//!   impl ComputerProperties-> pwdlastset(&self) -> i64
+//!   impl User              -> object_identifier(&self) -> &String
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::sync::Arc;
+
+use futures::stream::{self, StreamExt};
+use log::{debug, info, trace, warn};
+use tokio::net::TcpStream;
+use tokio::sync::Semaphore;
+use tokio::time::{timeout, Duration};
+
+use dcerpc::rrp::{RegistryClient, RegistrySession};
+use dcerpc::srvsvc::SrvsvcClient;
+use dcerpc::wkssvc::{WkstaUser, WkstaUserClient};
+use smb2_client::SmbClient;
+
+use crate::args::{CollectionMethod, Options};
+use crate::objects::common::UserComputerSession;
+use crate::objects::computer::Computer;
+use crate::objects::user::User;
+
+const DEFAULT_CONCURRENCY: usize = 10;      // ~ SharpHound --Throttle
+const DEFAULT_PORT_TIMEOUT_MS: u64 = 1_500; // 445 pre-check budget
+const DEFAULT_HOST_TIMEOUT_MS: u64 = 8_000; // whole per-host RPC budget
+const DEFAULT_EXPIRY_DAYS: i64 = 60;        // ~ SharpHound --ComputerExpiryDays
+
+// ----
+// Raw per-host findings (kept close to HasSession-rs)
+// ----
+
+struct SmbSession { user: String, _client: String }
+
+struct HostFindings {
+    computer_sid: String,
+    smb_sessions: Vec<SmbSession>,      // SRVSVC
+    logged_on:    Vec<WkstaUser>,       // WKSSVC
+    registry:     Vec<RegistrySession>, // WINREG
+    errors:       Vec<String>,
+}
+
+// Entry point called by run_modules
+pub async fn run(
+    args:      &Options,
+    users:     &[User],           // needed to resolve RPC principal names -> SIDs
+    computers: &mut Vec<Computer>,
+) -> Result<(), Box<dyn Error>> {
+    // Hard guard: DCOnly must never touch a machine.
+    if !args.collection_method.does_sessions() {
+        debug!("[sessions] collection method does not contact hosts - skipping");
+        return Ok(());
+    }
+
+    // 1) Build the name -> SID resolution table from the LDAP data collected upstream.
+    let sid_index = build_sid_index(users);
+
+    // 2) Select ACTIVE targets only (enabled + pwdLastSet within the expiry window).
+    //    The host is the computer FQDN (properties.name); no fqdn->ip lookup.
+    let expiry_days = DEFAULT_EXPIRY_DAYS;
+    let targets: Vec<(String, String)> = computers
+        .iter()
+        .filter(|c| is_active(c, expiry_days))
+        .map(|c| (c.properties().name().clone(), c.object_identifier().clone()))
+        .collect();
+
+    info!("[sessions] {} active target(s) after expiry/enabled filter", targets.len());
+
+    // 3) Enumerate with bounded concurrency (throttle) instead of a serial loop.
+    let sem = Arc::new(Semaphore::new(DEFAULT_CONCURRENCY));
+    let domain = args.domain.clone();
+    let user = args.username.clone().unwrap_or_default();
+    let password = args.password.clone().unwrap_or_default();
+    let nt_hash = parse_hash(args.hashes.as_deref()); // "LM:NT" | ":NT" | "NT" -> [u8;16]
+    let method = args.collection_method.clone();
+
+    let findings: Vec<HostFindings> = stream::iter(targets)
+        .map(|(host, computer_sid)| {
+            let (sem, domain, user, password, method) =
+                (sem.clone(), domain.clone(), user.clone(), password.clone(), method.clone());
+            let nt_hash = nt_hash;
+            async move {
+                let _permit = sem.acquire().await.unwrap();
+                enumerate_host(&host, computer_sid, &domain, &user, &password,
+                               nt_hash.as_ref(), &method).await
+            }
+        })
+        .buffer_unordered(DEFAULT_CONCURRENCY)
+        .collect()
+        .await;
+
+    // 4) Fold findings back into the matching Computer objects (resolving names -> SIDs).
+    let mut total_sessions = 0usize;
+    for hf in &findings {
+        total_sessions += apply_findings(computers, hf, &sid_index, &args.domain);
+        for e in &hf.errors { warn!("{e}"); }
+    }
+    info!("[sessions] {total_sessions} session(s) enumerated in total across {} host(s)",
+          findings.len());
+
+    Ok(())
+}
+
+// Per-host enumeration (adapted from HasSession-rs enumerate_host)
+async fn enumerate_host(
+    host: &str, computer_sid: String,
+    domain: &str, user: &str, password: &str,
+    nt_hash: Option<&[u8; 16]>,
+    method: &CollectionMethod,
+) -> HostFindings {
+    // SharpHound-style reachability pre-check: 445 open within budget
+    if !is_reachable(host, DEFAULT_PORT_TIMEOUT_MS).await {
+        trace!("[{host}] 445/tcp unreachable - skip");
+        return HostFindings {
+            computer_sid,
+            smb_sessions: Vec::new(), logged_on: Vec::new(), registry: Vec::new(),
+            errors: vec![format!("{host}: 445/tcp unreachable")],
+        };
+    }
+
+    // The RPC body accumulates into its OWN locals and returns them, so it never
+    // aliases the outer findings the timeout wrapper also needs (avoids E0499).
+    let work = async {
+        let mut smb_sessions = Vec::new();
+        let mut logged_on    = Vec::new();
+        let mut registry     = Vec::new();
+        let mut errors       = Vec::new();
+
+        // Inner block uses `?` for the fatal connect/auth/tree steps; the error
+        // is folded into `errors` instead of bubbling out of `work`.
+        let fatal: Result<(), String> = async {
+            let mut smb = SmbClient::connect(&format!("{host}:445")).await
+                .map_err(|e| format!("{host} connect: {e}"))?;
+
+            // SESSION_SETUP - NTLMv2 password OR pass-the-hash
+            match nt_hash {
+                Some(h) => smb.login_hash(host, domain, user, h).await
+                              .map_err(|e| format!("{host} auth(PTH): {e}"))?,
+                None    => smb.login(host, domain, user, password).await
+                              .map_err(|e| format!("{host} auth: {e}"))?,
+            }
+            smb.tree_connect(&format!(r"\\{host}\IPC$")).await
+               .map_err(|e| format!("{host} IPC$: {e}"))?;
+
+            if method.srvsvc() {
+                match srvsvc_sessions(&mut smb).await {
+                    Ok((_, 5)) => errors.push(format!("[{host}] SRVSVC rc=5 ACCESS_DENIED (hardened / non-admin)")),
+                    Ok((s, _)) => smb_sessions = s,
+                    Err(e)     => errors.push(format!("{host} SRVSVC: {e}")),
+                }
+            }
+            if method.wkssvc() {
+                match enum_wksta(&mut smb).await {
+                    Ok((_, 5)) => errors.push(format!("[{host}] WKSSVC rc=5 (local admin required)")),
+                    Ok((u, _)) => logged_on = dedup_wksta(u),
+                    Err(e)     => errors.push(format!("{host} WKSSVC: {e}")),
+                }
+            }
+            if method.registry() {
+                match enum_registry(&mut smb, domain, user, password, nt_hash, host).await {
+                    Ok(sids) => registry = sids,
+                    Err(e)   => errors.push(format!("{host} WINREG: {e} (RemoteRegistry stopped?)")),
+                }
+            }
+            Ok(())
+        }.await;
+
+        if let Err(e) = fatal { errors.push(e); }
+        (smb_sessions, logged_on, registry, errors)
+    };
+
+    // whole-host budget so a slow-but-open host can't stall a worker
+    match timeout(Duration::from_millis(DEFAULT_HOST_TIMEOUT_MS), work).await {
+        Ok((smb_sessions, logged_on, registry, errors)) => HostFindings {
+            computer_sid, smb_sessions, logged_on, registry, errors,
+        },
+        Err(_elapsed) => HostFindings {
+            computer_sid,
+            smb_sessions: Vec::new(), logged_on: Vec::new(), registry: Vec::new(),
+            errors: vec![format!("{host}: per-host timeout")],
+        },
+    }
+}
+
+// Reachability + activity helpers
+async fn is_reachable(host: &str, port_timeout_ms: u64) -> bool {
+    matches!(
+        timeout(Duration::from_millis(port_timeout_ms),
+                TcpStream::connect(format!("{host}:445"))).await,
+        Ok(Ok(_))
+    )
+}
+
+/// enabled + pwdLastSet within the expiry window (~ SharpHound ComputerExpiryDays).
+fn is_active(c: &Computer, expiry_days: i64) -> bool {
+    if !*c.properties().enabled() { return false; }
+    let pls = c.properties().pwdlastset(); // add: pub fn pwdlastset(&self) -> i64
+    if pls <= 0 { return false; }
+    let now = chrono::Utc::now().timestamp();
+    now - pls < expiry_days * 86_400
+}
+
+// Isolated RPC calls (unchanged from HasSession-rs)
+async fn srvsvc_sessions(smb: &mut SmbClient) -> anyhow::Result<(Vec<SmbSession>, u32)> {
+    let pipe = smb.open_pipe("srvsvc").await?;
+    let mut srv = SrvsvcClient::bind(smb, pipe).await?;
+    let (sessions, rc) = srv.enum_sessions().await?;
+    Ok((sessions.into_iter()
+        .map(|s| SmbSession { user: s.user, _client: s.client }).collect(), rc))
+}
+
+async fn enum_wksta(smb: &mut SmbClient) -> anyhow::Result<(Vec<WkstaUser>, u32)> {
+    let pipe = smb.open_pipe("wkssvc").await?;
+    let mut wk = WkstaUserClient::bind(smb, pipe).await?;
+    Ok(wk.enum_users().await?)
+}
+
+async fn enum_registry(smb: &mut SmbClient, domain: &str, user: &str,
+                       password: &str, nt_hash: Option<&[u8; 16]>, host: &str)
+    -> anyhow::Result<Vec<RegistrySession>>
+{
+    let mut reg = match nt_hash {
+        Some(h) => RegistryClient::connect_hash(smb, domain, user, h, host).await
+                       .map_err(|e| anyhow::anyhow!("{e}"))?,
+        None    => RegistryClient::connect(smb, domain, user, password, host).await
+                       .map_err(|e| anyhow::anyhow!("{e}"))?,
+    };
+    reg.logged_on_sids().await.map_err(|e| anyhow::anyhow!("{e}"))
+}
+
+/// Build the principal -> SID lookup from the users collected during LDAP.
+///
+/// `User::properties().name()` is already "SAMACCOUNTNAME@DOMAIN.FQDN" (UPPER),
+/// which we key directly. We also index the bare SAMAccountName as a fallback,
+/// because SRVSVC/WKSSVC hand back a bare username (no realm). Bare-SAM keys can
+/// collide across trusted domains; the fully-qualified key is always tried first.
+fn build_sid_index(users: &[User]) -> HashMap<String, String> {
+    let mut idx = HashMap::with_capacity(users.len() * 2);
+    for u in users {
+        let sid = u.object_identifier().clone(); // add: pub fn object_identifier(&self) -> &String
+        if sid.is_empty() { continue; }
+        let upn = u.properties().name().to_uppercase(); // SAM@DOMAIN.FQDN
+        if let Some(sam) = upn.split('@').next() {
+            // bare SAM: keep the first mapping, do not let a later duplicate clobber it
+            idx.entry(sam.to_string()).or_insert_with(|| sid.clone());
+        }
+        idx.insert(upn, sid);
+    }
+    idx
+}
+
+/// Resolve a principal string coming from an RPC call to a domain SID.
+///
+/// Handles "DOMAIN\\user", "DOMAIN/user" and bare "user"; drops empty / "?" /
+/// machine ("$") principals. Tries the fully-qualified key first, then bare SAM.
+fn resolve(raw: &str, idx: &HashMap<String, String>, domain: &str) -> Option<String> {
+    let bare = raw.rsplit(['\\', '/']).next().unwrap_or(raw).trim();
+    if bare.is_empty() || bare == "?" || bare.ends_with('$') {
+        return None;
+    }
+    let sam = bare.to_uppercase();
+    let upn = format!("{sam}@{}", domain.to_uppercase());
+    idx.get(&upn).or_else(|| idx.get(&sam)).cloned()
+}
+
+/// Construct a { UserSID, ComputerSID } link (fields are private -> use mutators).
+fn mk_link(user_sid: String, computer_sid: String) -> UserComputerSession {
+    let mut ucs = UserComputerSession::new();
+    *ucs.user_sid_mut() = user_sid;
+    *ucs.computer_sid_mut() = computer_sid;
+    ucs
+}
+
+/// De-duplicate WKSSVC logon sessions and drop machine accounts (noise on DCs).
+fn dedup_wksta(users: Vec<WkstaUser>) -> Vec<WkstaUser> {
+    use std::collections::BTreeSet;
+    let mut seen = BTreeSet::new();
+    users.into_iter()
+        .filter(|u| !u.username.ends_with('$'))
+        .filter(|u| seen.insert((u.logon_domain.clone(), u.username.clone())))
+        .collect()
+}
+
+/// Write one host's findings into the matching Computer object, and return the
+/// number of session links written for that host.
+///
+/// SRVSVC   -> Sessions            (resolve username -> UserSID)
+/// WKSSVC   -> PrivilegedSessions  (resolve username -> UserSID)
+/// WINREG   -> RegistrySessions    (r.sid is already a SID, no resolution)
+///
+/// Each block sets Collected = true; unresolved principals are logged at warn!
+/// rather than silently dropped, matching SharpHound's behaviour.
+fn apply_findings(
+    computers: &mut [Computer],
+    hf: &HostFindings,
+    sid_index: &HashMap<String, String>,
+    domain: &str,
+) -> usize {
+    let computer = match computers
+        .iter_mut()
+        .find(|c| c.object_identifier() == &hf.computer_sid)
+    {
+        Some(c) => c,
+        None => {
+            warn!("[sessions] no computer object for SID {}", hf.computer_sid);
+            return 0;
+        }
+    };
+    let comp_sid = hf.computer_sid.clone();
+    let fqdn = computer.properties().name().clone(); // clone before the mutable borrows
+    let mut count = 0usize;
+
+    // SRVSVC -> Sessions
+    {
+        let s = computer.sessions_mut(); // add: pub fn sessions_mut(&mut self) -> &mut Session
+        for sess in &hf.smb_sessions {
+            match resolve(&sess.user, sid_index, domain) {
+                Some(user_sid) => {
+                    trace!("[SRVSVC] {} has session on {fqdn}", sess.user);
+                    s.results_mut().push(mk_link(user_sid, comp_sid.clone()));
+                    count += 1;
+                }
+                None => warn!("[{comp_sid}] unresolved SRVSVC principal '{}'", sess.user),
+            }
+        }
+        *s.collected_mut() = true;
+    }
+
+    // WKSSVC -> PrivilegedSessions
+    {
+        let p = computer.privileged_sessions_mut(); // add: privileged_sessions_mut()
+        for u in &hf.logged_on {
+            match resolve(&u.username, sid_index, domain) {
+                Some(user_sid) => {
+                    trace!("[WKSSVC] {}\\{} has session on {fqdn}", u.logon_domain, u.username);
+                    p.results_mut().push(mk_link(user_sid, comp_sid.clone()));
+                    count += 1;
+                }
+                None => warn!("[{comp_sid}] unresolved WKSSVC principal '{}\\{}'",
+                               u.logon_domain, u.username),
+            }
+        }
+        *p.collected_mut() = true;
+    }
+
+    // WINREG -> RegistrySessions (SIDs already; no resolution needed)
+    {
+        let r = computer.registry_sessions_mut(); // add: registry_sessions_mut()
+        for reg in &hf.registry {
+            if reg.sid.is_empty() { continue; }
+            trace!("[WINREG] {} has session on {fqdn}", reg.sid);
+            r.results_mut().push(mk_link(reg.sid.clone(), comp_sid.clone()));
+            count += 1;
+        }
+        *r.collected_mut() = true;
+    }
+
+    debug!("[sessions] Total {count} session(s) on {fqdn}");
+    count
+}
+
+/// Parse a hash string into the 16-byte NT hash for pass-the-hash.
+///
+/// Accepts "LMHASH:NTHASH", ":NTHASH" or a bare 32-hex "NTHASH". Returns None
+/// when absent or malformed (caller then falls back to password auth).
+fn parse_hash(h: Option<&str>) -> Option<[u8; 16]> {
+    let raw = h?.trim();
+    let nt = raw.rsplit(':').next().unwrap_or(raw).trim();
+    if nt.len() != 32 || !nt.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let mut out = [0u8; 16];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&nt[i * 2..i * 2 + 2], 16).ok()?;
+    }
+    Some(out)
+}

--- a/src/objects/computer.rs
+++ b/src/objects/computer.rs
@@ -91,6 +91,15 @@ impl Computer {
     pub fn allowed_to_act_mut(&mut self) -> &mut Vec<Member> {
         &mut self.allowed_to_act
     }
+    pub fn sessions_mut(&mut self) -> &mut Session {
+        &mut self.sessions
+    }
+    pub fn privileged_sessions_mut(&mut self) -> &mut Session {
+        &mut self.privileged_sessions
+    }
+    pub fn registry_sessions_mut(&mut self) -> &mut Session {
+        &mut self.registry_sessions
+    }
 
     /// Function to parse and replace value for computer object.
     /// <https://bloodhound.readthedocs.io/en/latest/further-reading/json.html#computers>
@@ -528,8 +537,10 @@ impl ComputerProperties {
     pub fn get_is_dc(&self) -> &bool {
         &self.is_dc
     }
+    pub fn pwdlastset(&self) -> i64 { 
+        self.pwdlastset
+    }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/objects/user.rs
+++ b/src/objects/user.rs
@@ -61,6 +61,9 @@ impl User {
     pub fn aces(&self) -> &Vec<AceTemplate> {
         &self.aces
     }
+    pub fn object_identifier(&self) -> &String {
+        &self.object_identifier
+    }
 
     // Mutable access.
     pub fn properties_mut(&mut self) -> &mut UserProperties {


### PR DESCRIPTION
## Summary

Implements the session-collection feature tracked in #46. Adds `src/modules/sessions/mod.rs`, run after the LDAP phase from `run_modules`, which enumerates "who is connected where" over the three native RPC paths and folds the results into the existing BloodHound CE computer schema:

| RPC path                    | BloodHound field     | Required rights on the target |
|-----------------------------|----------------------|-------------------------------|
| SRVSVC / NetrSessionEnum    | `Sessions`           | Any authenticated domain user pre-2021; post [KB5001652](https://support.microsoft.com/topic/kb5001652) the `SrvsvcSessionInfo` ACL restricts it to local admins (else rc=5) |
| WKSSVC / NetrWkstaUserEnum  | `PrivilegedSessions` | Local administrator on the target |
| WINREG / HKEY_USERS | `RegistrySessions` | Remote Registry service running + caller allowed by the `winreg` key ACL for the HKU path (local admin by default on hardened hosts, but not intrinsically required; HKU itself grants Read to Everyone) |

## Collection methods

Extends `CollectionMethod` so the RPC paths can be selected individually:

- `All` / `Session` -> SRVSVC + WKSSVC + WINREG
- `RegistryOnly`    -> WINREG only (still opens the SMB session + IPC$, which WINREG rides on)
- `DCOnly`          -> LDAP only, the sessions module is skipped entirely

## SharpHound-style behaviour

- 445 reachability pre-check with a hard timeout, dead hosts are skipped;
- active-host filter on `pwdLastSet` age (ComputerExpiryDays, default 60 days)
  plus the `enabled` flag, to avoid wasting time on stale objects;
- bounded concurrency (throttle) instead of a serial loop, with a per-host budget;
- RPC principal names resolved to SIDs from the already-collected LDAP data;
  unresolved principals are logged, not silently dropped.

## Notes for review

- New dependencies: `futures`, `anyhow`, `smb2-client`, and the `dcerpc` stack
  (git dependency, not published on crates.io). `tokio` features made explicit.
- Adds small accessors used by the module: `Computer::{sessions_mut,
  privileged_sessions_mut, registry_sessions_mut}`, `ComputerProperties::pwdlastset`,
  `User::object_identifier`.
- `--collectionmethod` help string updated to advertise the new values.
- The SRVSVC path returns bare usernames, resolution falls back from the
  fully-qualified `SAM@DOMAIN.FQDN` key to the bare SAM, which can collide across
  trusted domains; flagged inline for discussion.

Since you self-assigned #46, feel free to squash, rework or cherry-pick as you
see fit rather than merging as-is.

Refs #46