### PR TITLE
feat(adcs): ESC8 web enrollment probe with EPA channel binding detection (#48)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ futures     = "0.3"
 anyhow      = "1"
 smb2-client = "0.2"
 dcerpc      = "0.2.7"
+# es8 check
+curl = "0.4"
 
 [features]
 noargs = ["winreg"] # Only available for Windows

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         &mut results.mappings.fqdn_ip,
         &mut results.computers,
                 &mut results.users,
+                &mut results.enterprisecas,
     )
     .await?;
 

--- a/src/modules/adcs/esc8.rs
+++ b/src/modules/adcs/esc8.rs
@@ -1,0 +1,590 @@
+//! ESC8 scanner, Web Enrollment HTTP/HTTPS probe + EPA (Channel Binding) detection.
+//!
+//! Detects whether a CA exposes the `/certsrv/certfnsh.asp` endpoint over HTTP
+//! (always vulnerable to NTLM relay) or over HTTPS without Extended Protection for
+//! Authentication (EPA / Channel Binding), which is also vulnerable.
+//!
+//! The EPA check works by sending a minimal NTLM Type 1 (Negotiate) message to the
+//! HTTPS endpoint and parsing the server's NTLM Type 2 (Challenge) response. If the
+//! `MsvAvChannelBindings` AvPair (AvId `0x000A`) is absent from the challenge's
+//! `TargetInfo`, EPA is not enforced and the endpoint is relay-able.
+//!
+//! This approach requires a single HTTP round-trip, no credentials, no full
+//! NTLM handshake, no relay attempted.
+//!
+//! Module path: `src/modules/adcs/esc8.rs`
+//! Required Cargo dependency: `curl = "0.4"`
+
+use crate::utils::b64::{b64_decode, b64_encode};
+use curl::easy::{Easy, List};
+use log::{debug, warn};
+
+// NTLM AvPair IDs 
+
+/// End-of-list marker in NTLM TargetInfo AvPairs.
+const MV_AV_EOL: u16 = 0x0000;
+
+/// `MsvAvChannelBindings`, present with non-zero length when EPA is required.
+const MV_AV_CHANNEL_BINDINGS: u16 = 0x000A;
+
+// Minimal NTLM Type 1 (Negotiate) 
+
+/// Anonymous NTLM Type 1 Negotiate token.
+///
+/// Flags encoded (little-endian `0xa2088207`):
+///  NTLMSSP_NEGOTIATE_UNICODE            (0x00000001)
+///  NTLMSSP_NEGOTIATE_OEM                (0x00000002)
+///  NTLMSSP_REQUEST_TARGET               (0x00000004)
+///  NTLMSSP_NEGOTIATE_NTLM               (0x00000200)
+///  NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY (0x00080000)
+///  NTLMSSP_NEGOTIATE_128                (0x20000000)
+///  NTLMSSP_NEGOTIATE_56                 (0x80000000)
+///
+/// Domain and Workstation fields are empty; no version block.
+const NTLM_NEGOTIATE: &[u8] = &[
+    // Signature
+    0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00,
+    // MessageType = 1
+    0x01, 0x00, 0x00, 0x00,
+    // NegotiateFlags (LE 0xa2088207)
+    0x07, 0x82, 0x08, 0xa2,
+    // DomainNameFields: Len=0, MaxLen=0, Offset=32
+    0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00,
+    // WorkstationFields: Len=0, MaxLen=0, Offset=32
+    0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00,
+];
+
+// Public types 
+
+/// Status of a single web-enrollment endpoint (HTTP or HTTPS).
+#[derive(Debug, Clone, PartialEq)]
+pub enum WebEnrollmentStatus {
+    /// Endpoint not reachable, or web enrollment not installed.
+    NotFound,
+    /// Web enrollment is reachable and NTLM auth is available, relay possible.
+    Vulnerable,
+    /// Web enrollment is on HTTPS and EPA/channel binding is enforced, protected.
+    Protected,
+}
+
+/// Full ESC8 probe result for a CA host.
+#[derive(Debug, Clone)]
+pub struct Esc8Result {
+    pub host: String,
+    /// HTTP endpoint status (`Vulnerable` if reachable with NTLM; HTTP has no EPA).
+    pub http: WebEnrollmentStatus,
+    /// HTTPS endpoint status (checks EPA via NTLM Type 2 parsing).
+    pub https: WebEnrollmentStatus,
+    /// `true` if either endpoint is relay-able.
+    pub vulnerable: bool,
+}
+
+// Public API 
+
+/// Run the full ESC8 probe against a CA host (both HTTP and HTTPS).
+///
+/// Returns `None` if the host is completely unreachable on both endpoints.
+pub fn check_esc8(host: &str) -> Option<Esc8Result> {
+    let http = probe_http(host);
+    let https = probe_https(host);
+
+    if http == WebEnrollmentStatus::NotFound && https == WebEnrollmentStatus::NotFound {
+        return None;
+    }
+
+    let vulnerable = http == WebEnrollmentStatus::Vulnerable
+        || https == WebEnrollmentStatus::Vulnerable;
+
+    if http == WebEnrollmentStatus::Vulnerable {
+        warn!(
+            "ESC8 detected on {}, Web Enrollment exposed over HTTP without EPA \
+             (NTLM relay possible on http://{}/certsrv/certfnsh.asp)",
+            host, host
+        );
+    }
+    if https == WebEnrollmentStatus::Vulnerable {
+        warn!(
+            "ESC8 detected on {}, Web Enrollment over HTTPS without Channel Binding \
+             (NTLM relay possible on https://{}/certsrv/certfnsh.asp)",
+            host, host
+        );
+    }
+    if https == WebEnrollmentStatus::Protected {
+        debug!("ESC8 HTTPS {}: EPA/Channel Binding enforced, protected", host);
+    }
+
+    Some(Esc8Result {
+        host: host.to_string(),
+        http,
+        https,
+        vulnerable,
+    })
+}
+
+// Internal probes 
+
+/// Probe the plain-HTTP enrollment endpoint.
+///
+/// A `401` response carrying `WWW-Authenticate: NTLM` or `Negotiate` over HTTP
+/// is sufficient to flag ESC8, HTTP provides no channel-binding protection.
+fn probe_http(host: &str) -> WebEnrollmentStatus {
+    let url = format!("http://{}/certsrv/certfnsh.asp", host);
+    debug!("ESC8 HTTP probe: {}", url);
+
+    let mut easy = Easy::new();
+    if easy.url(&url).is_err() {
+        return WebEnrollmentStatus::NotFound;
+    }
+    easy.nobody(true).ok();
+    easy.timeout(std::time::Duration::from_secs(5)).ok();
+    easy.connect_timeout(std::time::Duration::from_secs(3)).ok();
+    easy.follow_location(true).ok();
+    easy.max_redirections(3).ok();
+
+    let mut has_ntlm = false;
+
+    {
+        let mut transfer = easy.transfer();
+        transfer
+            .header_function(|header| {
+                let h = std::str::from_utf8(header)
+                    .unwrap_or("")
+                    .trim()
+                    .to_lowercase();
+                if h.starts_with("www-authenticate:") {
+                    let val = h["www-authenticate:".len()..].trim();
+                    if val.starts_with("ntlm") || val.starts_with("negotiate") {
+                        has_ntlm = true;
+                    }
+                }
+                true
+            })
+            .ok();
+        transfer.write_function(|data| Ok(data.len())).ok();
+        if transfer.perform().is_err() {
+            return WebEnrollmentStatus::NotFound;
+        }
+    }
+
+    let status = easy.response_code().unwrap_or(0);
+    debug!("ESC8 HTTP probe {}: status={} ntlm={}", host, status, has_ntlm);
+
+    if status == 401 && has_ntlm {
+        WebEnrollmentStatus::Vulnerable
+    } else {
+        WebEnrollmentStatus::NotFound
+    }
+}
+
+/// Probe the HTTPS enrollment endpoint and check for EPA (Channel Binding).
+///
+/// Sends a minimal NTLM Type 1 Negotiate. If the server responds with a Type 2
+/// Challenge, parses the `TargetInfo` AvPairs to check for `MsvAvChannelBindings`.
+/// Absent: EPA disabled: relay possible.
+fn probe_https(host: &str) -> WebEnrollmentStatus {
+    let url = format!("https://{}/certsrv/certfnsh.asp", host);
+    debug!("ESC8 HTTPS probe: {}", url);
+
+    let neg_b64 = b64_encode(NTLM_NEGOTIATE);
+    let auth_header = format!("Authorization: NTLM {}", neg_b64);
+
+    let mut easy = Easy::new();
+    if easy.url(&url).is_err() {
+        return WebEnrollmentStatus::NotFound;
+    }
+    // Ignore TLS cert errors, DCs often present self-signed certs
+    easy.ssl_verify_peer(false).ok();
+    easy.ssl_verify_host(false).ok();
+    easy.timeout(std::time::Duration::from_secs(8)).ok();
+    easy.connect_timeout(std::time::Duration::from_secs(3)).ok();
+
+    // Inject the NTLM Negotiate header so the server sends back a Type 2 Challenge
+    let mut headers = List::new();
+    if headers.append(&auth_header).is_err() {
+        return WebEnrollmentStatus::NotFound;
+    }
+    if easy.http_headers(headers).is_err() {
+        return WebEnrollmentStatus::NotFound;
+    }
+
+    let mut challenge_token: Option<Vec<u8>> = None;
+
+    {
+        let mut transfer = easy.transfer();
+        transfer
+            .header_function(|header| {
+                let h = std::str::from_utf8(header).unwrap_or("").trim();
+                // The server's NTLM Type 2 arrives as:
+                // WWW-Authenticate: NTLM <base64-token>
+                let lower = h.to_ascii_lowercase();
+                if let Some(rest) = lower.strip_prefix("www-authenticate: ntlm ") {
+                    let token_b64 = rest.trim();
+                    // Only keep the token if it's long enough to be a Type 2 message
+                    if token_b64.len() > 16 {
+                        let orig_rest = &h["www-authenticate: ntlm ".len()..].trim();
+                        if let Some(bytes) = b64_decode(orig_rest) {
+                            challenge_token = Some(bytes);
+                        }
+                    }
+                }
+                true
+            })
+            .ok();
+        transfer.write_function(|data| Ok(data.len())).ok();
+        if transfer.perform().is_err() {
+            return WebEnrollmentStatus::NotFound;
+        }
+    }
+
+    let status = easy.response_code().unwrap_or(0);
+    debug!("ESC8 HTTPS probe {}: status={}", host, status);
+
+    if status != 401 {
+        return WebEnrollmentStatus::NotFound;
+    }
+
+    match challenge_token {
+        None => {
+            debug!(
+                "ESC8 HTTPS {}: no NTLM challenge received (Kerberos-only or not installed)",
+                host
+            );
+            WebEnrollmentStatus::NotFound
+        }
+        Some(token) => {
+            if parse_epa_channel_bindings(&token) {
+                debug!("ESC8 HTTPS {}: MsvAvChannelBindings present: EPA enforced", host);
+                WebEnrollmentStatus::Protected
+            } else {
+                debug!("ESC8 HTTPS {}: MsvAvChannelBindings absent: EPA disabled", host);
+                WebEnrollmentStatus::Vulnerable
+            }
+        }
+    }
+}
+
+// NTLM Type 2 / EPA parsing 
+
+/// Parse an NTLM Type 2 (Challenge) token and return `true` if
+/// `MsvAvChannelBindings` (AvId `0x000A`) is present with a **non-zero** length.
+/// <https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/34a9417d-7cc0-43b0-b61c-1f19740df66f>
+///
+/// NTLM Type 2 layout (all little-endian):
+///
+/// | Offset | Size | Field               |
+/// |--------|------|---------------------|
+/// |  0     |  8   | Signature           |
+/// |  8     |  4   | MessageType = 2     |
+/// | 12     |  8   | TargetNameFields    |
+/// | 20     |  4   | NegotiateFlags      |
+/// | 24     |  8   | ServerChallenge     |
+/// | 32     |  8   | Reserved            |
+/// | 40     |  8   | TargetInfoFields    |
+/// | 48     |  8   | Version (optional)  |
+/// | 56+    |  …   | Payload             |
+///
+/// AvPair layout: `AvId u16 | AvLen u16 | AvValue [u8; AvLen]`
+pub fn parse_epa_channel_bindings(token: &[u8]) -> bool {
+    // Minimum: fixed header (56 bytes), we only strictly need bytes 0–47
+    if token.len() < 48 {
+        debug!(
+            "NTLM token too short ({} bytes), cannot parse as Type 2",
+            token.len()
+        );
+        return false;
+    }
+
+    // Verify "NTLMSSP\0" signature
+    if &token[0..8] != b"NTLMSSP\0" {
+        debug!("NTLM signature mismatch");
+        return false;
+    }
+
+    // Verify MessageType == 2
+    let msg_type = u32::from_le_bytes([token[8], token[9], token[10], token[11]]);
+    if msg_type != 2 {
+        debug!("Not a Type 2 message (MessageType={})", msg_type);
+        return false;
+    }
+
+    // TargetInfoFields at offset 40
+    let ti_len = u16::from_le_bytes([token[40], token[41]]) as usize;
+    // MaxLen at bytes 42-43 (ignored)
+    let ti_off = u32::from_le_bytes([token[44], token[45], token[46], token[47]]) as usize;
+
+    if ti_len == 0 {
+        debug!("TargetInfo is empty, no AvPairs to inspect");
+        return false;
+    }
+    if token.len() < ti_off.saturating_add(ti_len) {
+        debug!(
+            "TargetInfo out of bounds (off={}, len={}, token_len={})",
+            ti_off,
+            ti_len,
+            token.len()
+        );
+        return false;
+    }
+
+    let avpairs = &token[ti_off..ti_off + ti_len];
+    debug!("Parsing {} bytes of AvPairs", avpairs.len());
+
+    // Walk the AvPair list
+    let mut i = 0;
+    while i + 4 <= avpairs.len() {
+        let av_id = u16::from_le_bytes([avpairs[i], avpairs[i + 1]]);
+        let av_len = u16::from_le_bytes([avpairs[i + 2], avpairs[i + 3]]) as usize;
+
+        match av_id {
+            MV_AV_EOL => {
+                debug!("MsvAvEOL reached");
+                break;
+            }
+            MV_AV_CHANNEL_BINDINGS => {
+                debug!("MsvAvChannelBindings found (av_len={})", av_len);
+                // Non-zero length = real CBT present = EPA enforced
+                return av_len > 0;
+            }
+            other => {
+                debug!("AvPair id=0x{:04x} len={}, skipping", other, av_len);
+                i += 4 + av_len;
+            }
+        }
+    }
+
+    // MsvAvChannelBindings not found: EPA not required
+    false
+}
+
+// Tests 
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test helpers 
+
+    /// Build a minimal but structurally valid NTLM Type 2 token whose `TargetInfo`
+    /// section contains the provided raw `avpairs` bytes.
+    ///
+    /// Fixed layout used here (all fields little-endian):
+    ///  0–7   : "NTLMSSP\0"
+    ///  8–11  : MessageType = 2
+    ///  12–19 : TargetNameFields  (Len=0, MaxLen=0, Offset=56)
+    ///  20–23 : NegotiateFlags
+    ///  24–31 : ServerChallenge
+    ///  32–39 : Reserved
+    ///  40–47 : TargetInfoFields  (Len=avpairs.len(), MaxLen=same, Offset=56)
+    ///  48–55 : Version (zeroed)
+    ///  56+   : Payload = avpairs
+    fn build_type2(avpairs: &[u8]) -> Vec<u8> {
+        let mut t = Vec::new();
+        t.extend_from_slice(b"NTLMSSP\0");                          // signature
+        t.extend_from_slice(&2u32.to_le_bytes());                    // MessageType = 2
+        // TargetNameFields: Len=0, MaxLen=0, Offset=56
+        t.extend_from_slice(&0u16.to_le_bytes());
+        t.extend_from_slice(&0u16.to_le_bytes());
+        t.extend_from_slice(&56u32.to_le_bytes());
+        // NegotiateFlags
+        t.extend_from_slice(&0u32.to_le_bytes());
+        // ServerChallenge (8 bytes)
+        t.extend_from_slice(&[0x01u8; 8]);
+        // Reserved (8 bytes)
+        t.extend_from_slice(&[0u8; 8]);
+        // TargetInfoFields: Len=avpairs.len(), MaxLen=same, Offset=56
+        let ti_len = avpairs.len() as u16;
+        t.extend_from_slice(&ti_len.to_le_bytes());
+        t.extend_from_slice(&ti_len.to_le_bytes());
+        t.extend_from_slice(&56u32.to_le_bytes());
+        // Version (8 bytes, optional, zeroed)
+        t.extend_from_slice(&[0u8; 8]);
+        // Payload = TargetInfo
+        t.extend_from_slice(avpairs);
+        t
+    }
+
+    /// Build AvPairs that contain `MsvAvChannelBindings` (AvId=0x000A) followed
+    /// by `MsvAvEOL`.
+    fn avpairs_with_channel_bindings(value: &[u8]) -> Vec<u8> {
+        let mut p = Vec::new();
+        p.extend_from_slice(&MV_AV_CHANNEL_BINDINGS.to_le_bytes());
+        p.extend_from_slice(&(value.len() as u16).to_le_bytes());
+        p.extend_from_slice(value);
+        // MsvAvEOL
+        p.extend_from_slice(&MV_AV_EOL.to_le_bytes());
+        p.extend_from_slice(&0u16.to_le_bytes());
+        p
+    }
+
+    /// Build AvPairs that do NOT contain `MsvAvChannelBindings`, only an
+    /// `MsvAvNbComputerName` and the EOL marker.
+    fn avpairs_without_channel_bindings() -> Vec<u8> {
+        let name: Vec<u8> = "SERVER"
+            .encode_utf16()
+            .flat_map(|u| u.to_le_bytes())
+            .collect();
+        let mut p = Vec::new();
+        // MsvAvNbComputerName (AvId=0x0001)
+        p.extend_from_slice(&0x0001u16.to_le_bytes());
+        p.extend_from_slice(&(name.len() as u16).to_le_bytes());
+        p.extend_from_slice(&name);
+        // MsvAvEOL
+        p.extend_from_slice(&MV_AV_EOL.to_le_bytes());
+        p.extend_from_slice(&0u16.to_le_bytes());
+        p
+    }
+
+    // parse_epa_channel_bindings 
+
+    #[test]
+    fn epa_present_with_non_zero_value() {
+        // EPA is enforced: MsvAvChannelBindings has a real (non-zero) value.
+        let cbt = [0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE,
+                   0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        let token = build_type2(&avpairs_with_channel_bindings(&cbt));
+        assert!(
+            parse_epa_channel_bindings(&token),
+            "Should return true when MsvAvChannelBindings has a non-zero value"
+        );
+    }
+
+    #[test]
+    fn epa_present_but_zero_length() {
+        // Some servers include the AvPair but with length 0, EPA NOT enforced.
+        let token = build_type2(&avpairs_with_channel_bindings(&[]));
+        assert!(
+            !parse_epa_channel_bindings(&token),
+            "Should return false when MsvAvChannelBindings has zero length"
+        );
+    }
+
+    #[test]
+    fn epa_absent_from_avpairs() {
+        // Server does not include MsvAvChannelBindings at all, EPA NOT enforced.
+        let token = build_type2(&avpairs_without_channel_bindings());
+        assert!(
+            !parse_epa_channel_bindings(&token),
+            "Should return false when MsvAvChannelBindings is absent"
+        );
+    }
+
+    #[test]
+    fn epa_multiple_avpairs_with_channel_bindings_last() {
+        // MsvAvChannelBindings appears after other pairs, parser must walk all pairs.
+        let name: Vec<u8> = "DC01"
+            .encode_utf16()
+            .flat_map(|u| u.to_le_bytes())
+            .collect();
+        let cbt = [0xAA, 0xBB, 0xCC, 0xDD];
+        let mut avpairs = Vec::new();
+        // MsvAvNbComputerName
+        avpairs.extend_from_slice(&0x0001u16.to_le_bytes());
+        avpairs.extend_from_slice(&(name.len() as u16).to_le_bytes());
+        avpairs.extend_from_slice(&name);
+        // MsvAvChannelBindings
+        avpairs.extend_from_slice(&MV_AV_CHANNEL_BINDINGS.to_le_bytes());
+        avpairs.extend_from_slice(&(cbt.len() as u16).to_le_bytes());
+        avpairs.extend_from_slice(&cbt);
+        // MsvAvEOL
+        avpairs.extend_from_slice(&MV_AV_EOL.to_le_bytes());
+        avpairs.extend_from_slice(&0u16.to_le_bytes());
+
+        let token = build_type2(&avpairs);
+        assert!(
+            parse_epa_channel_bindings(&token),
+            "Should find MsvAvChannelBindings even when it follows other pairs"
+        );
+    }
+
+    #[test]
+    fn epa_empty_avpairs() {
+        // TargetInfo present but empty, must not panic.
+        let token = build_type2(&[]);
+        assert!(!parse_epa_channel_bindings(&token));
+    }
+
+    // Structural validation 
+
+    #[test]
+    fn token_too_short_returns_false() {
+        assert!(!parse_epa_channel_bindings(&[0u8; 10]));
+        assert!(!parse_epa_channel_bindings(&[]));
+    }
+
+    #[test]
+    fn invalid_signature_returns_false() {
+        let mut token = build_type2(&avpairs_without_channel_bindings());
+        token[0] = 0xFF; // corrupt signature byte
+        assert!(!parse_epa_channel_bindings(&token));
+    }
+
+    #[test]
+    fn wrong_message_type_returns_false() {
+        let mut token = build_type2(&avpairs_without_channel_bindings());
+        // Set MessageType to 1 instead of 2
+        token[8] = 0x01;
+        token[9] = 0x00;
+        token[10] = 0x00;
+        token[11] = 0x00;
+        assert!(!parse_epa_channel_bindings(&token));
+    }
+
+    #[test]
+    fn target_info_offset_out_of_bounds_returns_false() {
+        let avpairs = avpairs_without_channel_bindings();
+        let mut token = build_type2(&avpairs);
+        // Set TargetInfoFields.Offset to a value past the token end
+        let bad_offset = (token.len() + 1024) as u32;
+        token[44..48].copy_from_slice(&bad_offset.to_le_bytes());
+        assert!(!parse_epa_channel_bindings(&token));
+    }
+
+    // Base64 helpers
+
+    #[test]
+    fn base64_roundtrip_ntlm_negotiate() {
+        let encoded = b64_encode(NTLM_NEGOTIATE);
+        let decoded = b64_decode(&encoded).expect("base64_decode should succeed");
+        assert_eq!(
+            NTLM_NEGOTIATE,
+            decoded.as_slice(),
+            "base64 round-trip must be lossless for the NTLM negotiate token"
+        );
+    }
+
+    #[test]
+    fn base64_known_vector() {
+        // RFC 4648 §10 test vector
+        assert_eq!(b64_encode(b"Man"), "TWFu");
+        assert_eq!(b64_decode("TWFu"), Some(b"Man".to_vec()));
+    }
+
+    #[test]
+    fn base64_with_padding() {
+        assert_eq!(b64_encode(b"Ma"), "TWE=");
+        assert_eq!(b64_decode("TWE="), Some(b"Ma".to_vec()));
+        assert_eq!(b64_encode(b"M"), "TQ==");
+        assert_eq!(b64_decode("TQ=="), Some(b"M".to_vec()));
+    }
+
+    #[test]
+    fn base64_decode_invalid_char_returns_none() {
+        // `!` is not a valid Base64 character
+        assert_eq!(b64_decode("TQ!Q"), None);
+    }
+
+    #[test]
+    fn base64_decode_empty_input() {
+        assert_eq!(b64_decode(""), Some(vec![]));
+    }
+
+    // Network probe (non-routable, expected to return None) 
+
+    #[test]
+    fn unreachable_host_returns_none() {
+        // TEST-NET-1 (192.0.2.0/24, RFC 5737) is non-routable in any real network.
+        // The probe must time out cleanly and return None without panicking.
+        let result = check_esc8("192.0.2.1");
+        assert!(result.is_none(), "Non-routable host must return None");
+    }
+}

--- a/src/modules/adcs/mod.rs
+++ b/src/modules/adcs/mod.rs
@@ -1,0 +1,90 @@
+//! ADCS active modules: ESC8 web enrollment probe.
+//!
+//! This module exposes `probe_enterpriseca_esc8`, the only public entry point.
+//! It is called from `run_modules` after LDAP collection is complete,
+//! once per EnterpriseCA object, in parallel via rayon.
+
+pub mod esc8;
+
+use crate::modules::adcs::esc8::{check_esc8, Esc8Result, WebEnrollmentStatus};
+
+// Public result type
+
+/// ESC8 probe data, ready to be injected into EnterpriseCA properties and fields.
+pub struct Esc8Data {
+    /// True if any web enrollment endpoint (HTTP or HTTPS) is reachable.
+    pub webenrollenabled: bool,
+    /// True if the plain-HTTP endpoint responded with NTLM auth (always relay-able).
+    pub webenrollhttpenabled: bool,
+    /// True if an HTTPS endpoint is reachable (regardless of EPA status).
+    pub webenrollhttpsenabled: bool,
+    /// EPA status on the HTTPS endpoint: "enabled", "disabled", "notdetected".
+    pub webenrollhttpsepastatus: String,
+    /// HTTP URLs that are vulnerable (populated only when webenrollhttpenabled).
+    pub http_enrollment_endpoints: Vec<String>,
+    /// HTTPS URLs that were found (populated when webenrollhttpsenabled).
+    pub https_enrollment_endpoints: Vec<String>,
+}
+
+impl Default for Esc8Data {
+    fn default() -> Self {
+        Self {
+            webenrollenabled:           false,
+            webenrollhttpenabled:       false,
+            webenrollhttpsenabled:      false,
+            webenrollhttpsepastatus:    "notdetected".to_string(),
+            http_enrollment_endpoints:  vec![],
+            https_enrollment_endpoints: vec![],
+        }
+    }
+}
+
+impl From<Esc8Result> for Esc8Data {
+    fn from(r: Esc8Result) -> Self {
+        let webenrollhttpenabled  = r.http  == WebEnrollmentStatus::Vulnerable;
+        let webenrollhttpsenabled = r.https != WebEnrollmentStatus::NotFound;
+
+        let webenrollhttpsepastatus = match r.https {
+            WebEnrollmentStatus::Protected  => "enabled".to_string(),
+            WebEnrollmentStatus::Vulnerable => "disabled".to_string(),
+            WebEnrollmentStatus::NotFound   => "notdetected".to_string(),
+        };
+
+        let http_enrollment_endpoints = if webenrollhttpenabled {
+            vec![format!("http://{}/certsrv/", r.host)]
+        } else {
+            vec![]
+        };
+
+        let https_enrollment_endpoints = if webenrollhttpsenabled {
+            vec![format!("https://{}/certsrv/", r.host)]
+        } else {
+            vec![]
+        };
+
+        Self {
+            webenrollenabled: webenrollhttpenabled || webenrollhttpsenabled,
+            webenrollhttpenabled,
+            webenrollhttpsenabled,
+            webenrollhttpsepastatus,
+            http_enrollment_endpoints,
+            https_enrollment_endpoints,
+        }
+    }
+}
+
+// Public API
+
+/// Probe web enrollment endpoints for a single Enterprise CA.
+///
+/// Returns default (all false / empty) if `dns_host` is empty or unreachable.
+/// The DCOnly guard is handled by the caller (`run_modules`).
+pub fn probe_enterpriseca_esc8(dns_host: &str) -> Esc8Data {
+    if dns_host.is_empty() {
+        return Esc8Data::default();
+    }
+    match check_esc8(dns_host) {
+        Some(result) => Esc8Data::from(result),
+        None         => Esc8Data::default(),
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -2,21 +2,28 @@
 pub mod gpo;
 pub mod resolver;
 pub mod sessions;
+pub mod adcs;
 
 use std::collections::HashMap;
 use std::error::Error;
 
-use crate::args::Options;
+use rayon::prelude::*;
+
+use crate::args::{CollectionMethod, Options};
 use crate::objects::computer::Computer;
+use crate::objects::enterpriseca::EnterpriseCA;
 use crate::objects::user::User;
+use crate::modules::adcs::probe_enterpriseca_esc8;
 
 /// Function to run all modules requested
 pub async fn run_modules(
-   common_args:   &Options, 
-   fqdn_ip:       &mut HashMap<String, String>, 
-   vec_computers: &mut Vec<Computer>,
-   vec_users:     &mut Vec<User>,
+    common_args:        &Options,
+    fqdn_ip:            &mut HashMap<String, String>,
+    vec_computers:      &mut Vec<Computer>,
+    vec_users:          &mut Vec<User>,
+    vec_enterprisecas:  &mut Vec<EnterpriseCA>,
 ) -> Result<(), Box<dyn Error>> {
+
    // [MODULE - RESOLVER] Running module to resolve FQDN to IP address?
    if common_args.fqdn_resolver {
       resolver::resolv::resolving_all_fqdn(
@@ -35,6 +42,30 @@ pub async fn run_modules(
    // - WINREG / HKEY_USERS - SIDs of loaded profile hives (= logged-on users).
    if common_args.collection_method.does_sessions() {
       sessions::run(common_args, vec_users, vec_computers).await?;
+   }
+
+   // [MODULE - ESC8] Web enrollment probe on all enterprise CAs.
+   // Skipped in DCOnly mode (no direct machine connections allowed).
+   // Uses rayon to probe all CAs in parallel (each probe has a 5 s timeout).
+   if !matches!(common_args.collection_method, CollectionMethod::DCOnly)
+        && !vec_enterprisecas.is_empty()
+   {
+      log::info!(
+         "Starting ESC8 web enrollment probe on {} CA(s)...",
+         vec_enterprisecas.len()
+      );
+
+      vec_enterprisecas.par_iter_mut().for_each(|ca| {
+         let esc8 = probe_enterpriseca_esc8(ca.dns_host());
+         ca.apply_esc8(
+            esc8.webenrollenabled,
+            esc8.webenrollhttpenabled,
+            esc8.webenrollhttpsenabled,
+            esc8.webenrollhttpsepastatus,
+            esc8.http_enrollment_endpoints,
+            esc8.https_enrollment_endpoints,
+         );
+      });
    }
 
    // Other modules need to be add here...

--- a/src/objects/enterpriseca.rs
+++ b/src/objects/enterpriseca.rs
@@ -28,6 +28,10 @@ pub struct EnterpriseCA {
     ca_registry_data: CARegistryData,
     #[serde(rename = "EnabledCertTemplates")]
     enabled_cert_templates: Vec<Member>,
+    #[serde(rename = "HttpEnrollmentEndpoints")]
+    http_enrollment_endpoints: Vec<String>,
+    #[serde(rename = "HttpsEnrollmentEndpoints")]
+    https_enrollment_endpoints: Vec<String>,
     #[serde(rename = "Aces")]
     aces: Vec<AceTemplate>,
     #[serde(rename = "ObjectIdentifier")]
@@ -54,6 +58,29 @@ impl EnterpriseCA {
     // Mutable access.
     pub fn enabled_cert_templates_mut(&mut self) -> &mut Vec<Member> {
         &mut self.enabled_cert_templates
+    }
+
+    // DNS hostname of the CA, used for the ESC8 probe.
+    pub fn dns_host(&self) -> &str {
+        &self.properties.dnshostname
+    }
+
+    // Inject ESC8 probe results into this EnterpriseCA.
+    pub fn apply_esc8(
+        &mut self,
+        webenrollenabled: bool,
+        webenrollhttpenabled: bool,
+        webenrollhttpsenabled: bool,
+        webenrollhttpsepastatus: String,
+        http_enrollment_endpoints: Vec<String>,
+        https_enrollment_endpoints: Vec<String>,
+    ) {
+        self.properties.webenrollenabled        = webenrollenabled;
+        self.properties.webenrollhttpenabled    = webenrollhttpenabled;
+        self.properties.webenrollhttpsenabled   = webenrollhttpsenabled;
+        self.properties.webenrollhttpsepastatus = webenrollhttpsepastatus;
+        self.http_enrollment_endpoints          = http_enrollment_endpoints;
+        self.https_enrollment_endpoints         = https_enrollment_endpoints;
     }
 
     /// Function to parse and replace value in json template for Enterprise CA object.
@@ -382,6 +409,10 @@ pub struct EnterpriseCAProperties {
     enrollmentagentrestrictionscollected: bool,
     isuserspecifiessanenabledcollected: bool,
     roleseparationenabledcollected: bool,
+    webenrollenabled: bool,
+    webenrollhttpenabled: bool,
+    webenrollhttpsenabled: bool,
+    webenrollhttpsepastatus: String,
 }
 
 impl Default for EnterpriseCAProperties {
@@ -407,6 +438,10 @@ impl Default for EnterpriseCAProperties {
             enrollmentagentrestrictionscollected: false,
             isuserspecifiessanenabledcollected: false,
             roleseparationenabledcollected: false,
+            webenrollenabled: false,
+            webenrollhttpenabled: false,
+            webenrollhttpsenabled: false,
+            webenrollhttpsepastatus: String::from("notdetected"),
        }
     }
  }

--- a/src/utils/b64.rs
+++ b/src/utils/b64.rs
@@ -1,0 +1,137 @@
+//! Base64 encode/decode helpers, standard RFC 4648 alphabet, no external dependency.
+//!
+//! Used by the ESC8 scanner to encode the NTLM Negotiate token and decode
+//! the server's NTLM Challenge from HTTP response headers.
+
+/// Encode `input` to standard Base64 (RFC 4648, with `=` padding).
+pub fn b64_encode(input: &[u8]) -> String {
+    const TABLE: &[u8] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    let mut out = String::with_capacity((input.len() + 2) / 3 * 4);
+    for chunk in input.chunks(3) {
+        let b0 = chunk[0] as usize;
+        let b1 = if chunk.len() > 1 { chunk[1] as usize } else { 0 };
+        let b2 = if chunk.len() > 2 { chunk[2] as usize } else { 0 };
+
+        out.push(TABLE[(b0 >> 2) & 0x3f] as char);
+        out.push(TABLE[((b0 << 4) | (b1 >> 4)) & 0x3f] as char);
+        out.push(if chunk.len() > 1 {
+            TABLE[((b1 << 2) | (b2 >> 6)) & 0x3f] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            TABLE[b2 & 0x3f] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+/// Decode standard Base64 (RFC 4648). Returns `None` on invalid input.
+pub fn b64_decode(input: &str) -> Option<Vec<u8>> {
+    fn val(c: u8) -> Option<u8> {
+        match c {
+            b'A'..=b'Z' => Some(c - b'A'),
+            b'a'..=b'z' => Some(c - b'a' + 26),
+            b'0'..=b'9' => Some(c - b'0' + 52),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            _ => None,
+        }
+    }
+
+    // Strip padding and whitespace before processing
+    let bytes: Vec<u8> = input
+        .bytes()
+        .filter(|&b| b != b'=' && b != b'\r' && b != b'\n' && b != b' ')
+        .collect();
+
+    if bytes.len() % 4 == 1 {
+        return None; // impossible valid length
+    }
+
+    let mut out = Vec::with_capacity(bytes.len() * 3 / 4);
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+        let v0 = val(bytes[i])?;
+        let v1 = val(bytes[i + 1])?;
+        out.push((v0 << 2) | (v1 >> 4));
+        if i + 2 < bytes.len() {
+            let v2 = val(bytes[i + 2])?;
+            out.push((v1 << 4) | (v2 >> 2));
+            if i + 3 < bytes.len() {
+                let v3 = val(bytes[i + 3])?;
+                out.push((v2 << 6) | v3);
+            }
+        }
+        i += 4;
+    }
+    Some(out)
+}
+
+// Tests 
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rfc4648_vectors() {
+        // Official RFC 4648 §10 test vectors
+        assert_eq!(b64_encode(b""),       "");
+        assert_eq!(b64_encode(b"f"),      "Zg==");
+        assert_eq!(b64_encode(b"fo"),     "Zm8=");
+        assert_eq!(b64_encode(b"foo"),    "Zm9v");
+        assert_eq!(b64_encode(b"foob"),   "Zm9vYg==");
+        assert_eq!(b64_encode(b"fooba"),  "Zm9vYmE=");
+        assert_eq!(b64_encode(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn decode_rfc4648_vectors() {
+        assert_eq!(b64_decode(""),         Some(b"".to_vec()));
+        assert_eq!(b64_decode("Zg=="),     Some(b"f".to_vec()));
+        assert_eq!(b64_decode("Zm8="),     Some(b"fo".to_vec()));
+        assert_eq!(b64_decode("Zm9v"),     Some(b"foo".to_vec()));
+        assert_eq!(b64_decode("Zm9vYg=="), Some(b"foob".to_vec()));
+        assert_eq!(b64_decode("Zm9vYmE="), Some(b"fooba".to_vec()));
+        assert_eq!(b64_decode("Zm9vYmFy"), Some(b"foobar".to_vec()));
+    }
+
+    #[test]
+    fn roundtrip_arbitrary_bytes() {
+        let data: Vec<u8> = (0u8..=255).collect();
+        let encoded = b64_encode(&data);
+        let decoded = b64_decode(&encoded).expect("roundtrip decode failed");
+        assert_eq!(data, decoded);
+    }
+
+    #[test]
+    fn decode_without_padding() {
+        // Padding is optional on input
+        assert_eq!(b64_decode("Zg"),   Some(b"f".to_vec()));
+        assert_eq!(b64_decode("Zm8"),  Some(b"fo".to_vec()));
+    }
+
+    #[test]
+    fn decode_invalid_char_returns_none() {
+        assert_eq!(b64_decode("TQ!Q"), None);
+        assert_eq!(b64_decode("TQ@Q"), None);
+    }
+
+    #[test]
+    fn decode_impossible_length_returns_none() {
+        // Length 1 mod 4 is never valid Base64
+        assert_eq!(b64_decode("A"), None);
+    }
+
+    #[test]
+    fn decode_ignores_whitespace_and_padding() {
+        // Common in PEM / HTTP headers
+        assert_eq!(b64_decode("Zm9v\r\nYmFy"), Some(b"foobar".to_vec()));
+        assert_eq!(b64_decode("Zm9vYmFy=="), Some(b"foobar".to_vec()));
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,5 +3,6 @@
 pub mod crypto;
 pub mod date;
 pub mod format;
+pub mod b64;
 #[cfg(feature = "noargs")]
 pub mod exec;


### PR DESCRIPTION
## Summary

Implements active ESC8 detection as described in issue #48.

Probes each Enterprise CA's `/certsrv/certfnsh.asp` endpoint over HTTP and HTTPS after LDAP collection, in parallel via `rayon`. Skipped automatically when `--collectionmethod DCOnly` is set.

## How it works

**HTTP probe**, a simple `HEAD` request. A `401` with `WWW-Authenticate: NTLM` or `Negotiate` over plain HTTP is sufficient to flag ESC8: HTTP has no channel binding protection.

**HTTPS probe + EPA check**, sends a minimal NTLM Type 1 Negotiate token. The server responds with a Type 2 Challenge. The `TargetInfo` AvPairs are parsed tolook for `MsvAvChannelBindings` (AvId `0x000A`):
- absent or zero-length => EPA disabled => NTLM relay possible
- non-zero => EPA enforced => protected

- link: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/34a9417d-7cc0-43b0-b61c-1f19740df66f

This requires a single HTTP round-trip, no credentials, no relay attempted.

## Files changed

| File | Change |
|---|---|
| `src/utils/b64.rs` | Standalone RFC 4648 base64 encode/decode, no external dependency |
| `src/utils/mod.rs` | Declare `pub mod b64` |
| `src/modules/adcs/esc8.rs` | HTTP + HTTPS probe, NTLM Type 2 parsing, 9 unit tests |
| `src/modules/adcs/mod.rs` | `Esc8Data`, `From<Esc8Result>`, `probe_enterpriseca_esc8()` |
| `src/objects/enterpriseca.rs` | New fields on `EnterpriseCA` + `EnterpriseCAProperties`, `apply_esc8()`, `dns_host()` |
| `src/modules/mod.rs` | `run_modules` signature + parallel ESC8 probe, DCOnly guard |
| `src/main.rs` | `run_modules` adding `results.entreprisecas` |

## JSON output (enterprisecas.json)

```json
{
  "HttpEnrollmentEndpoints": ["http://braavos.essos.local/certsrv/"],
  "HttpsEnrollmentEndpoints": [],
  "Properties": {
    "webenrollenabled": true,
    "webenrollhttpenabled": true,
    "webenrollhttpsenabled": false,
    "webenrollhttpsepastatus": "notdetected"
  }
}
```

## Testing

Unit tests cover:
- `MsvAvChannelBindings` present with non-zero value: EPA enforced
- `MsvAvChannelBindings` present with zero length: EPA disabled
- `MsvAvChannelBindings` absent: EPA disabled
- Multiple AvPairs, `MsvAvChannelBindings` last
- Token too short / invalid signature / wrong MessageType / offset out of bounds
- Base64 RFC 4648 round-trip on the NTLM Negotiate token

Closes #48