### PR TITLE
feat(gpo): parse local group policy directives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,6 +2272,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2621,6 +2630,7 @@ dependencies = [
  "once_cell",
  "picky",
  "picky-krb",
+ "quick-xml",
  "rayon",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ picky = "=7.0.0-rc.17"
 winreg = { version = "0.52", optional = true }
 sha1 = "0.10"
 regex = "1"
+quick-xml = "0.37"
 once_cell = "1.19"
 bincode = "2.0.1"
 obfstr = "0.4.1"

--- a/src/modules/gpo/gpttmpl.rs
+++ b/src/modules/gpo/gpttmpl.rs
@@ -1,4 +1,7 @@
-use crate::modules::gpo::types::{GpoError, GptTmplPolicy, PrivilegeAssignment};
+use crate::modules::gpo::types::{
+    GpoError, GptTmplPolicy, PrivilegeAssignment, RestrictedGroupDirective,
+    RestrictedGroupOperation,
+};
 
 /// Decodes raw bytes of a GptTmpl.inf security template into a UTF-8 `String`.
 ///
@@ -97,7 +100,8 @@ fn decode_utf16be(bytes: &[u8]) -> Result<String, GpoError> {
 }
 
 /// Parses a decoded `GptTmpl.inf` content string into a structured `GptTmplPolicy`.
-/// Returns `Err(GpoError::MalformedContent)` if any syntax error occurs within `[Privilege Rights]`.
+/// Returns `Err(GpoError::MalformedContent)` for malformed assignments in
+/// `[Privilege Rights]` or `[Group Membership]`.
 ///
 /// # Comments and Syntax
 /// Per Microsoft Windows INF specifications and MS-GPSB section 2.2.6:
@@ -107,6 +111,7 @@ fn decode_utf16be(bytes: &[u8]) -> Result<String, GpoError> {
 pub fn parse_gpttmpl(content: &str) -> Result<GptTmplPolicy, GpoError> {
     let mut current_section: Option<String> = None;
     let mut privilege_rights: Vec<PrivilegeAssignment> = Vec::new();
+    let mut restricted_groups: Vec<RestrictedGroupDirective> = Vec::new();
 
     for (line_idx, line) in content.lines().enumerate() {
         let line_no = line_idx + 1;
@@ -170,11 +175,52 @@ pub fn parse_gpttmpl(content: &str) -> Result<GptTmplPolicy, GpoError> {
                     privilege_rights
                         .push(PrivilegeAssignment::new(privilege.to_string(), principals));
                 }
+            } else if section == "group membership" {
+                let (raw_key, raw_val) = trimmed.split_once('=').ok_or_else(|| {
+                    GpoError::MalformedContent(format!(
+                        "invalid group membership entry at line {line_no}: missing '='"
+                    ))
+                })?;
+                let key = raw_key.trim();
+                let key_lower = key.to_ascii_lowercase();
+                let (target, operation) = if key_lower.ends_with("__members") {
+                    (
+                        &key[..key.len() - "__Members".len()],
+                        RestrictedGroupOperation::ReplaceMembers,
+                    )
+                } else if key_lower.ends_with("__memberof") {
+                    (
+                        &key[..key.len() - "__Memberof".len()],
+                        RestrictedGroupOperation::AddToParentGroups,
+                    )
+                } else {
+                    return Err(GpoError::MalformedContent(format!(
+                        "invalid group membership entry at line {line_no}: expected __Members or __Memberof suffix"
+                    )));
+                };
+                let target = target.trim();
+                if target.is_empty() {
+                    return Err(GpoError::MalformedContent(format!(
+                        "invalid group membership entry at line {line_no}: empty target group"
+                    )));
+                }
+                let val_clean = raw_val.split(';').next().unwrap_or_default();
+                let principals = val_clean
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string)
+                    .collect();
+                restricted_groups
+                    .push(RestrictedGroupDirective::new(target, operation, principals));
             }
         }
     }
 
-    Ok(GptTmplPolicy::with_privilege_rights(privilege_rights))
+    Ok(GptTmplPolicy::with_entries(
+        privilege_rights,
+        restricted_groups,
+    ))
 }
 
 /// Parses raw bytes of a `GptTmpl.inf` security template directly into a `GptTmplPolicy`.
@@ -282,6 +328,103 @@ SeRemoteInteractiveLogonRight = *S-1-5-32-555
             }
             other => panic!("Unexpected error type: {other:?}"),
         }
+    }
+
+    #[test]
+    fn parses_restricted_groups_without_applying_graph_semantics() {
+        let content = r#"
+[Group Membership]
+*S-1-5-32-544__Members = *S-1-5-21-1-2-3-1001,DOMAIN\Helpdesk
+DOMAIN\Helpdesk__Memberof = *S-1-5-32-555
+*S-1-5-32-546__Members =
+"#;
+        let policy = parse_gpttmpl(content).unwrap();
+        let directives = policy.restricted_groups();
+        assert_eq!(directives.len(), 3);
+        assert_eq!(directives[0].target(), "*S-1-5-32-544");
+        assert_eq!(
+            directives[0].operation(),
+            RestrictedGroupOperation::ReplaceMembers
+        );
+        assert_eq!(
+            directives[0].principals(),
+            &["*S-1-5-21-1-2-3-1001", "DOMAIN\\Helpdesk"]
+        );
+        assert_eq!(
+            directives[1].operation(),
+            RestrictedGroupOperation::AddToParentGroups
+        );
+        assert!(directives[2].principals().is_empty());
+    }
+
+    #[test]
+    fn rejects_unknown_restricted_group_suffixes() {
+        let content = "[Group Membership]\nAdministrators__Unknown = DOMAIN\\alice\n";
+        assert!(matches!(
+            parse_gpttmpl(content),
+            Err(GpoError::MalformedContent(_))
+        ));
+    }
+
+    #[test]
+    fn restricted_groups_preserve_comments_crlf_names_and_empty_values() {
+        let content = "; synthetic fixture\r\n[Group Membership]\r\n  Local Operators__Members = DOMAIN\\alice, svc#backup ; comment\r\nLocal Operators__Memberof = *S-1-5-32-544, *S-1-5-32-555\r\nEmpty Group__Memberof = ; empty membership\r\n";
+        let policy = parse_gpttmpl(content).unwrap();
+        let groups = policy.restricted_groups();
+        assert_eq!(groups.len(), 3);
+        assert_eq!(groups[0].target(), "Local Operators");
+        assert_eq!(
+            groups[0].operation(),
+            RestrictedGroupOperation::ReplaceMembers
+        );
+        assert_eq!(groups[0].principals(), &["DOMAIN\\alice", "svc#backup"]);
+        assert_eq!(groups[1].target(), "Local Operators");
+        assert_eq!(
+            groups[1].operation(),
+            RestrictedGroupOperation::AddToParentGroups
+        );
+        assert_eq!(groups[1].principals(), &["*S-1-5-32-544", "*S-1-5-32-555"]);
+        assert!(groups[2].principals().is_empty());
+    }
+
+    #[test]
+    fn restricted_groups_reject_missing_equals_and_empty_targets() {
+        for entry in [
+            "Administrators__Members : DOMAIN\\alice",
+            "__Members = DOMAIN\\alice",
+            "__Memberof = *S-1-5-32-544",
+        ] {
+            assert!(matches!(
+                parse_gpttmpl(&format!("[Group Membership]\n{entry}\n")),
+                Err(GpoError::MalformedContent(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn restricted_groups_decode_canonical_utf16le() {
+        let text = "[Group Membership]\r\n*S-1-5-32-544__Members = DOMAIN\\alice, *S-1-5-21-1-2-3-1001\r\nLocal Operators__Memberof = *S-1-5-32-555\r\n";
+        let mut bytes = vec![0xFF, 0xFE];
+        for unit in text.encode_utf16() {
+            bytes.extend_from_slice(&unit.to_le_bytes());
+        }
+        let policy = parse_gpttmpl_bytes(&bytes).unwrap();
+        let groups = policy.restricted_groups();
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].target(), "*S-1-5-32-544");
+        assert_eq!(
+            groups[0].operation(),
+            RestrictedGroupOperation::ReplaceMembers
+        );
+        assert_eq!(
+            groups[0].principals(),
+            &["DOMAIN\\alice", "*S-1-5-21-1-2-3-1001"]
+        );
+        assert_eq!(
+            groups[1].operation(),
+            RestrictedGroupOperation::AddToParentGroups
+        );
+        assert_eq!(groups[1].principals(), &["*S-1-5-32-555"]);
     }
 
     #[test]

--- a/src/modules/gpo/groups_xml.rs
+++ b/src/modules/gpo/groups_xml.rs
@@ -1,0 +1,537 @@
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::Reader;
+
+use crate::modules::gpo::types::{
+    GpoError, GppGroupAction, GppGroupMember, GppLocalGroup, GppMemberAction,
+};
+
+#[derive(Default)]
+struct PendingGroup {
+    sid: Option<String>,
+    name: Option<String>,
+    action: Option<GppGroupAction>,
+    disabled: bool,
+    delete_all_users: bool,
+    delete_all_groups: bool,
+    has_item_level_targeting: bool,
+    members: Vec<GppGroupMember>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Element {
+    Groups,
+    Group,
+    Properties,
+    Members,
+    Member,
+    Filters,
+    Other,
+}
+
+impl Element {
+    fn from_name(name: &[u8]) -> Self {
+        match name {
+            b"Groups" => Self::Groups,
+            b"Group" => Self::Group,
+            b"Properties" => Self::Properties,
+            b"Members" => Self::Members,
+            b"Member" => Self::Member,
+            b"Filters" => Self::Filters,
+            _ => Self::Other,
+        }
+    }
+}
+
+/// Parses UTF-8 Group Policy Preferences `Groups.xml` into local-group directives.
+/// Empty input represents no directives; malformed documents return an error.
+///
+/// MS-GPPREF sections 2.2.1.1 and 2.2.1.11.3 define `disabled` on the outer
+/// `Groups` and on `Group/Properties`. `Group disabled` is additionally tolerated
+/// for compatibility with input accepted by the initial parser. Disabled items
+/// are omitted, including when their unused membership attributes are incomplete.
+///
+/// Item-Level Targeting is detected, not evaluated. A future applicability layer
+/// must evaluate it before applying membership; targeted items cannot be applied
+/// globally. Unknown subtrees (including `User` and filter contents) are ignored.
+pub fn parse_groups_xml(content: &[u8]) -> Result<Vec<GppLocalGroup>, GpoError> {
+    use Element::*;
+
+    let mut reader = Reader::from_reader(content);
+    reader.config_mut().trim_text(true);
+    // Share the same structural checks for <Element/> and <Element></Element>.
+    reader.config_mut().expand_empty_elements = true;
+    let mut path = Vec::new();
+    let mut root_seen = false;
+    let mut root_disabled = false;
+    let mut groups = Vec::new();
+    let mut pending: Option<PendingGroup> = None;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(event)) => {
+                let element = Element::from_name(event.local_name().as_ref());
+                match (path.as_slice(), element) {
+                    ([], Groups) if !root_seen => {
+                        root_seen = true;
+                        root_disabled = bool_attribute(&event, b"disabled")?;
+                    }
+                    ([], _) => {
+                        return Err(malformed("expected a single Groups root element"));
+                    }
+                    ([Groups], Group) => {
+                        pending = Some(PendingGroup {
+                            disabled: root_disabled || bool_attribute(&event, b"disabled")?,
+                            ..PendingGroup::default()
+                        });
+                    }
+                    ([Groups, Group], Properties) => {
+                        if let Some(group) = pending.as_mut() {
+                            group.disabled |= bool_attribute(&event, b"disabled")?;
+                            if !group.disabled {
+                                if group.action.is_some() {
+                                    return Err(malformed("duplicate Group Properties element"));
+                                }
+                                group.sid = attribute(&event, b"groupSid")?;
+                                group.name = attribute(&event, b"groupName")?;
+                                group.action = Some(parse_group_action(
+                                    attribute(&event, b"action")?.as_deref().unwrap_or("U"),
+                                )?);
+                                group.delete_all_users = bool_attribute(&event, b"deleteAllUsers")?;
+                                group.delete_all_groups =
+                                    bool_attribute(&event, b"deleteAllGroups")?;
+                            }
+                        }
+                    }
+                    ([Groups, Group, Properties, Members], Member) => {
+                        if let Some(group) = pending.as_mut().filter(|group| !group.disabled) {
+                            group.members.push(parse_member(&event)?);
+                        }
+                    }
+                    ([Groups, Group], Filters) => {
+                        if let Some(group) = pending.as_mut() {
+                            group.has_item_level_targeting = true;
+                        }
+                    }
+                    _ => {}
+                }
+                path.push(element);
+            }
+            Ok(Event::End(_)) => {
+                let element = path.pop();
+                if element == Some(Group) && path == [Groups] {
+                    let group = pending
+                        .take()
+                        .ok_or_else(|| malformed("unexpected Group end"))?;
+                    if group.disabled {
+                        continue;
+                    }
+                    let action = group
+                        .action
+                        .ok_or_else(|| malformed("GPP group is missing Properties"))?;
+                    let group = GppLocalGroup::new(
+                        group.sid,
+                        group.name,
+                        action,
+                        group.delete_all_users,
+                        group.delete_all_groups,
+                        group.has_item_level_targeting,
+                        group.members,
+                    );
+                    if group.target().is_none() {
+                        return Err(malformed("GPP group is missing groupSid and groupName"));
+                    }
+                    groups.push(group);
+                }
+            }
+            Ok(Event::Text(text)) if !text.is_empty() => {
+                return Err(malformed("unexpected text in Groups.xml"));
+            }
+            Ok(Event::DocType(_) | Event::CData(_)) => {
+                return Err(malformed("unsupported DTD or CDATA in Groups.xml"));
+            }
+            Ok(Event::Eof) => break,
+            Ok(_) => {}
+            Err(error) => {
+                return Err(malformed(format!(
+                    "invalid Groups.xml near byte {}: {error}",
+                    reader.error_position()
+                )));
+            }
+        }
+    }
+
+    if !path.is_empty() {
+        return Err(malformed("unterminated Groups.xml element"));
+    }
+    Ok(groups)
+}
+
+fn malformed(message: impl Into<String>) -> GpoError {
+    GpoError::MalformedContent(message.into())
+}
+
+fn attribute(event: &BytesStart<'_>, name: &[u8]) -> Result<Option<String>, GpoError> {
+    let mut value = None;
+    for attribute in event.attributes() {
+        let attribute =
+            attribute.map_err(|error| malformed(format!("invalid XML attribute: {error}")))?;
+        if attribute.key.local_name().as_ref() == name {
+            if value.is_some() {
+                return Err(malformed("duplicate XML attribute"));
+            }
+            value = Some(
+                attribute
+                    .unescape_value()
+                    .map_err(|error| malformed(format!("invalid XML attribute value: {error}")))?
+                    .into_owned(),
+            );
+        }
+    }
+    Ok(value)
+}
+
+fn bool_attribute(event: &BytesStart<'_>, name: &[u8]) -> Result<bool, GpoError> {
+    match attribute(event, name)?.as_deref().map(str::trim) {
+        None | Some("0") => Ok(false),
+        Some("1") => Ok(true),
+        Some(value) if value.eq_ignore_ascii_case("true") => Ok(true),
+        Some(value) if value.eq_ignore_ascii_case("false") => Ok(false),
+        _ => Err(malformed("invalid boolean XML attribute")),
+    }
+}
+
+fn parse_group_action(value: &str) -> Result<GppGroupAction, GpoError> {
+    match value {
+        value if value.eq_ignore_ascii_case("C") => Ok(GppGroupAction::Create),
+        value if value.eq_ignore_ascii_case("D") => Ok(GppGroupAction::Delete),
+        value if value.eq_ignore_ascii_case("R") => Ok(GppGroupAction::Replace),
+        value if value.eq_ignore_ascii_case("U") => Ok(GppGroupAction::Update),
+        _ => Err(malformed(format!("unsupported GPP group action '{value}'"))),
+    }
+}
+
+fn parse_member(event: &BytesStart<'_>) -> Result<GppGroupMember, GpoError> {
+    let action =
+        attribute(event, b"action")?.ok_or_else(|| malformed("GPP member is missing action"))?;
+    let action = match action.as_str() {
+        value if value.eq_ignore_ascii_case("ADD") => GppMemberAction::Add,
+        value if value.eq_ignore_ascii_case("REMOVE") => GppMemberAction::Remove,
+        value => {
+            return Err(malformed(format!(
+                "unsupported GPP member action '{value}'"
+            )))
+        }
+    };
+    let member = GppGroupMember::new(
+        attribute(event, b"sid")?,
+        attribute(event, b"name")?,
+        action,
+    );
+    if member.principal().is_none() {
+        return Err(malformed("GPP member is missing sid and name"));
+    }
+    Ok(member)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_item(properties: &str, members: &str) -> Result<Vec<GppLocalGroup>, GpoError> {
+        parse_groups_xml(format!(
+            "<Groups><Group><Properties {properties}><Members>{members}</Members></Properties></Group></Groups>"
+        ).as_bytes())
+    }
+
+    #[test]
+    fn preserves_sid_precedence_actions_and_targeting() {
+        let xml = br#"<?xml version="1.0" encoding="utf-8"?>
+<Groups><Group><Properties action="R" groupName="Administrators" groupSid="S-1-5-32-544" deleteAllUsers="1" deleteAllGroups="0"><Members><Member name="DOMAIN\alice" sid="S-1-5-21-1-2-3-1001" action="ADD"/><Member name="DOMAIN\old" action="REMOVE"/></Members></Properties><Filters><FilterOs bool="AND"/></Filters></Group></Groups>"#;
+        let groups = parse_groups_xml(xml).unwrap();
+        assert_eq!(groups.len(), 1);
+        let group = &groups[0];
+        assert_eq!(group.target(), Some("S-1-5-32-544"));
+        assert_eq!(group.name(), Some("Administrators"));
+        assert_eq!(group.action(), GppGroupAction::Replace);
+        assert!(group.delete_all_users());
+        assert!(!group.delete_all_groups());
+        assert!(group.has_item_level_targeting());
+        assert_eq!(group.members().len(), 2);
+        assert_eq!(group.members()[0].principal(), Some("S-1-5-21-1-2-3-1001"));
+        assert_eq!(group.members()[0].action(), GppMemberAction::Add);
+        assert_eq!(group.members()[1].action(), GppMemberAction::Remove);
+    }
+
+    #[test]
+    fn empty_member_sid_falls_back_to_name_without_trimming() {
+        for sid in ["", " ", "&#x9;&#xA;&#xD;"] {
+            for name in [r"DOMAIN\alice", r" DOMAIN\Help  Desk "] {
+                let groups = parse_item(
+                    r#"groupName="Administrators""#,
+                    &format!(r#"<Member sid="{sid}" name="{name}" action="ADD"/>"#),
+                )
+                .unwrap();
+                let member = &groups[0].members()[0];
+                assert_eq!(member.sid(), None);
+                assert_eq!(member.principal(), Some(name));
+            }
+        }
+    }
+
+    #[test]
+    fn empty_group_sid_falls_back_to_name_without_trimming() {
+        for sid in ["", " ", "&#x9;&#xA;&#xD;"] {
+            for name in ["Administrators", " Local  Operators "] {
+                let groups =
+                    parse_item(&format!(r#"groupSid="{sid}" groupName="{name}""#), "").unwrap();
+                assert_eq!(groups[0].sid(), None);
+                assert_eq!(groups[0].target(), Some(name));
+            }
+        }
+    }
+
+    #[test]
+    fn empty_names_are_absent_when_sids_are_present() {
+        let groups = parse_item(
+            r#"groupSid="S-1-5-32-544" groupName=" ""#,
+            r#"<Member sid="S-1-5-21-1-2-3-1001" name="" action="ADD"/>"#,
+        )
+        .unwrap();
+        assert_eq!(groups[0].name(), None);
+        assert_eq!(groups[0].members()[0].name(), None);
+        assert_eq!(
+            groups[0].members()[0].principal(),
+            Some("S-1-5-21-1-2-3-1001")
+        );
+    }
+
+    #[test]
+    fn rejects_missing_or_blank_identities() {
+        for attributes in ["", r#"sid="" name=" ""#, r#"name="&#x9;""#] {
+            assert!(matches!(
+                parse_item(
+                    r#"groupName="Administrators""#,
+                    &format!(r#"<Member {attributes} action="ADD"/>"#)
+                ),
+                Err(GpoError::MalformedContent(_))
+            ));
+        }
+        for attributes in ["", r#"groupSid="" groupName=" ""#, r#"groupName="&#x9;""#] {
+            assert!(matches!(
+                parse_item(attributes, ""),
+                Err(GpoError::MalformedContent(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn root_disabled_suppresses_every_item() {
+        for disabled in ["1", "true", "TRUE"] {
+            let xml = format!(
+                r#"<Groups disabled="{disabled}"><Group><Properties groupName="Administrators"/></Group><Group><Properties groupName="Remote Desktop Users"/></Group></Groups>"#
+            );
+            assert!(parse_groups_xml(xml.as_bytes()).unwrap().is_empty());
+        }
+    }
+
+    #[test]
+    fn root_enabled_preserves_items() {
+        for disabled in ["0", "false", "FALSE"] {
+            let xml = format!(
+                r#"<Groups disabled="{disabled}"><Group><Properties groupName="Administrators"/></Group></Groups>"#
+            );
+            assert_eq!(parse_groups_xml(xml.as_bytes()).unwrap().len(), 1);
+        }
+    }
+
+    #[test]
+    fn properties_disabled_suppresses_only_that_item() {
+        let xml = br#"<Groups><Group><Properties disabled="1" groupName="Skip"/></Group><Group><Properties disabled="0" groupName="Keep"/></Group></Groups>"#;
+        let groups = parse_groups_xml(xml).unwrap();
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].target(), Some("Keep"));
+    }
+
+    #[test]
+    fn tolerates_group_disabled_without_overriding_properties() {
+        let xml = br#"<Groups><Group disabled="1"><Properties disabled="0" groupName="Skip"/></Group><Group disabled="0"><Properties disabled="1" groupName="Skip too"/></Group><Group disabled="0"><Properties groupName="Keep"/></Group></Groups>"#;
+        let groups = parse_groups_xml(xml).unwrap();
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].target(), Some("Keep"));
+    }
+
+    #[test]
+    fn disabled_items_do_not_require_unused_membership_attributes() {
+        for xml in [
+            r#"<Groups disabled="1"><Group/></Groups>"#,
+            r#"<Groups><Group disabled="1"/></Groups>"#,
+            r#"<Groups><Group><Properties disabled="1"><Members><Member/></Members></Properties></Group></Groups>"#,
+        ] {
+            assert!(parse_groups_xml(xml.as_bytes()).unwrap().is_empty());
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_disabled_and_delete_flags() {
+        for xml in [
+            r#"<Groups disabled="unknown"/>"#,
+            r#"<Groups><Group disabled="unknown"/></Groups>"#,
+            r#"<Groups><Group><Properties disabled="unknown" groupName="Admins"/></Group></Groups>"#,
+            r#"<Groups><Group><Properties groupName="Admins" deleteAllUsers="unknown"/></Group></Groups>"#,
+            r#"<Groups><Group><Properties groupName="Admins" deleteAllGroups="unknown"/></Group></Groups>"#,
+        ] {
+            assert!(matches!(
+                parse_groups_xml(xml.as_bytes()),
+                Err(GpoError::MalformedContent(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn missing_member_action_is_an_error() {
+        let result = parse_item(
+            r#"groupName="Administrators""#,
+            r#"<Member name="DOMAIN\alice"/>"#,
+        );
+        assert!(
+            matches!(result, Err(GpoError::MalformedContent(message)) if message.contains("missing action"))
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_member_actions() {
+        for action in ["", " ", "DELETE", "DEL", "UNKNOWN"] {
+            assert!(matches!(
+                parse_item(
+                    r#"groupName="Administrators""#,
+                    &format!(r#"<Member name="DOMAIN\alice" action="{action}"/>"#)
+                ),
+                Err(GpoError::MalformedContent(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn preserves_group_actions_and_defaults_only_missing_action_to_update() {
+        for (action, expected) in [
+            ("C", GppGroupAction::Create),
+            ("D", GppGroupAction::Delete),
+            ("R", GppGroupAction::Replace),
+            ("U", GppGroupAction::Update),
+        ] {
+            let groups =
+                parse_item(&format!(r#"groupName="Admins" action="{action}""#), "").unwrap();
+            assert_eq!(groups[0].action(), expected);
+        }
+        let groups = parse_item(r#"groupName="Admins""#, "").unwrap();
+        assert_eq!(groups[0].action(), GppGroupAction::Update);
+        for action in ["", "X"] {
+            assert!(matches!(
+                parse_item(&format!(r#"groupName="Admins" action="{action}""#), ""),
+                Err(GpoError::MalformedContent(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn preserves_delete_flags_and_false_defaults() {
+        for (attributes, expected) in [
+            ("", (false, false)),
+            (r#"deleteAllUsers="1""#, (true, false)),
+            (r#"deleteAllGroups="1""#, (false, true)),
+            (r#"deleteAllUsers="1" deleteAllGroups="1""#, (true, true)),
+            (r#"deleteAllUsers="0" deleteAllGroups="0""#, (false, false)),
+        ] {
+            let groups = parse_item(&format!(r#"groupName="Admins" {attributes}"#), "").unwrap();
+            assert_eq!(
+                (groups[0].delete_all_users(), groups[0].delete_all_groups()),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_empty_input_and_empty_groups() {
+        for xml in ["", " \r\n", "<Groups/>", "<Groups></Groups>"] {
+            assert!(parse_groups_xml(xml.as_bytes()).unwrap().is_empty());
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_truncated_and_multiple_root_documents() {
+        for xml in [
+            "<",
+            "<Groups>",
+            "<Groups><Group>",
+            r#"<Groups><Group><Properties groupName="Admins"/>"#,
+            r#"<Groups><Group><Properties groupName="Admins"/></Group>"#,
+            "<Groups><Group></Groups>",
+            "<Groups/><Groups/>",
+            "<Other/>",
+            "not xml",
+            "<Groups/>trailing",
+            "<Groups><!",
+            "<Groups></Groups></Groups>",
+        ] {
+            assert!(
+                matches!(
+                    parse_groups_xml(xml.as_bytes()),
+                    Err(GpoError::MalformedContent(_))
+                ),
+                "{xml}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_missing_or_duplicate_properties() {
+        for xml in [
+            "<Groups><Group/></Groups>",
+            "<Groups><Group></Group></Groups>",
+            r#"<Groups><Group><Properties groupName="First"/><Properties groupName="Second"/></Group></Groups>"#,
+        ] {
+            assert!(matches!(
+                parse_groups_xml(xml.as_bytes()),
+                Err(GpoError::MalformedContent(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn scopes_members_and_targeting_to_the_correct_item() {
+        let xml = br#"<Groups><User><Properties userName="Ignored"/></User><Group><Properties groupName="First"><Members><Member name="DOMAIN\alice" action="ADD"></Member></Members></Properties><Filters><Group><Properties groupName="Not a directive"><Members><Member name="DOMAIN\other" action="ADD"/></Members></Properties></Group></Filters></Group><Group><Properties groupName="Second"/><Filters/></Group><Group><Properties groupName="Third"/></Group></Groups>"#;
+        let groups = parse_groups_xml(xml).unwrap();
+        assert_eq!(
+            groups.iter().map(GppLocalGroup::target).collect::<Vec<_>>(),
+            vec![Some("First"), Some("Second"), Some("Third")]
+        );
+        assert_eq!(groups[0].members().len(), 1);
+        assert_eq!(groups[0].members()[0].principal(), Some(r"DOMAIN\alice"));
+        assert!(groups[0].has_item_level_targeting());
+        assert!(groups[1].has_item_level_targeting());
+        assert!(!groups[2].has_item_level_targeting());
+        assert!(groups[2].members().is_empty());
+    }
+
+    #[test]
+    fn accepts_namespace_prefixes_and_unescapes_names() {
+        let xml = br#"<g:Groups xmlns:g="urn:synthetic:gpp"><g:Group><g:Properties groupName="Local &amp; Operators"><g:Members><g:Member name="DOMAIN\a&amp;b" action="ADD"/></g:Members></g:Properties></g:Group></g:Groups>"#;
+        let groups = parse_groups_xml(xml).unwrap();
+        assert_eq!(groups[0].target(), Some("Local & Operators"));
+        assert_eq!(groups[0].members()[0].principal(), Some(r"DOMAIN\a&b"));
+    }
+
+    #[test]
+    fn rejects_duplicate_attributes_and_unknown_entities() {
+        for properties in [
+            r#"groupName="Admins" groupName="Other""#,
+            r#"groupName="&unknown;""#,
+            r#"groupName="Admins" broken"#,
+        ] {
+            assert!(matches!(
+                parse_item(properties, ""),
+                Err(GpoError::MalformedContent(_))
+            ));
+        }
+    }
+}

--- a/src/modules/gpo/mod.rs
+++ b/src/modules/gpo/mod.rs
@@ -1,10 +1,17 @@
 //! Group Policy Object (GPO) processing and parsing modules.
 //!
 //! Provides utilities for parsing Group Policy templates, such as
-//! `GptTmpl.inf` security privilege assignments.
+//! `GptTmpl.inf` privilege and Restricted Groups assignments and GPP `Groups.xml`.
+//! These parsers preserve directives; retrieval, applicability and graph edges
+//! belong to future layers.
 
 pub mod gpttmpl;
+pub mod groups_xml;
 pub mod types;
 
 pub use gpttmpl::{decode_gpttmpl_bytes, parse_gpttmpl, parse_gpttmpl_bytes};
-pub use types::{GpoError, GptTmplPolicy, PrivilegeAssignment};
+pub use groups_xml::parse_groups_xml;
+pub use types::{
+    GpoError, GppGroupAction, GppGroupMember, GppLocalGroup, GppMemberAction, GptTmplPolicy,
+    PrivilegeAssignment, RestrictedGroupDirective, RestrictedGroupOperation,
+};

--- a/src/modules/gpo/types.rs
+++ b/src/modules/gpo/types.rs
@@ -81,6 +81,7 @@ impl PrivilegeAssignment {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct GptTmplPolicy {
     privilege_rights: Vec<PrivilegeAssignment>,
+    restricted_groups: Vec<RestrictedGroupDirective>,
 }
 
 impl GptTmplPolicy {
@@ -91,7 +92,21 @@ impl GptTmplPolicy {
 
     /// Creates a new `GptTmplPolicy` with the given privilege rights.
     pub fn with_privilege_rights(privilege_rights: Vec<PrivilegeAssignment>) -> Self {
-        Self { privilege_rights }
+        Self {
+            privilege_rights,
+            restricted_groups: Vec::new(),
+        }
+    }
+
+    /// Creates a policy containing both privilege assignments and Restricted Groups directives.
+    pub fn with_entries(
+        privilege_rights: Vec<PrivilegeAssignment>,
+        restricted_groups: Vec<RestrictedGroupDirective>,
+    ) -> Self {
+        Self {
+            privilege_rights,
+            restricted_groups,
+        }
     }
 
     /// Returns a slice of all privilege assignments.
@@ -104,6 +119,179 @@ impl GptTmplPolicy {
         self.privilege_rights
             .iter()
             .find(|p| p.privilege.eq_ignore_ascii_case(privilege_name))
+    }
+
+    /// Returns the Restricted Groups directives in source order.
+    pub fn restricted_groups(&self) -> &[RestrictedGroupDirective] {
+        &self.restricted_groups
+    }
+}
+
+/// Describes how a Restricted Groups entry changes local group membership.
+///
+/// The parser preserves policy intent and deliberately does not mutate graph edges.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RestrictedGroupOperation {
+    /// `__Members`: the listed principals are the complete membership configured by the policy.
+    ReplaceMembers,
+    /// `__Memberof`: the target group is added to each listed parent group.
+    AddToParentGroups,
+}
+
+/// A single entry from the `[Group Membership]` section of `GptTmpl.inf`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RestrictedGroupDirective {
+    target: String,
+    operation: RestrictedGroupOperation,
+    principals: Vec<String>,
+}
+
+impl RestrictedGroupDirective {
+    pub fn new(
+        target: impl Into<String>,
+        operation: RestrictedGroupOperation,
+        principals: Vec<String>,
+    ) -> Self {
+        Self {
+            target: target.into(),
+            operation,
+            principals,
+        }
+    }
+
+    pub fn target(&self) -> &str {
+        &self.target
+    }
+
+    pub fn operation(&self) -> RestrictedGroupOperation {
+        self.operation
+    }
+
+    pub fn principals(&self) -> &[String] {
+        &self.principals
+    }
+}
+
+/// Action requested by a Group Policy Preferences local-group item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GppGroupAction {
+    Create,
+    Delete,
+    Replace,
+    Update,
+}
+
+/// Action requested for a member inside a GPP local-group item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GppMemberAction {
+    Add,
+    Remove,
+}
+
+fn nonempty_identity(value: Option<String>) -> Option<String> {
+    value.filter(|value| !value.trim().is_empty())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GppGroupMember {
+    sid: Option<String>,
+    name: Option<String>,
+    action: GppMemberAction,
+}
+
+impl GppGroupMember {
+    pub fn new(sid: Option<String>, name: Option<String>, action: GppMemberAction) -> Self {
+        Self {
+            sid: nonempty_identity(sid),
+            name: nonempty_identity(name),
+            action,
+        }
+    }
+
+    /// Returns the nonempty SID when present, otherwise the nonempty name.
+    pub fn principal(&self) -> Option<&str> {
+        self.sid.as_deref().or(self.name.as_deref())
+    }
+
+    pub fn sid(&self) -> Option<&str> {
+        self.sid.as_deref()
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    pub fn action(&self) -> GppMemberAction {
+        self.action
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GppLocalGroup {
+    sid: Option<String>,
+    name: Option<String>,
+    action: GppGroupAction,
+    delete_all_users: bool,
+    delete_all_groups: bool,
+    has_item_level_targeting: bool,
+    members: Vec<GppGroupMember>,
+}
+
+impl GppLocalGroup {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        sid: Option<String>,
+        name: Option<String>,
+        action: GppGroupAction,
+        delete_all_users: bool,
+        delete_all_groups: bool,
+        has_item_level_targeting: bool,
+        members: Vec<GppGroupMember>,
+    ) -> Self {
+        Self {
+            sid: nonempty_identity(sid),
+            name: nonempty_identity(name),
+            action,
+            delete_all_users,
+            delete_all_groups,
+            has_item_level_targeting,
+            members,
+        }
+    }
+
+    /// Returns the nonempty group SID when present, otherwise the nonempty group name.
+    pub fn target(&self) -> Option<&str> {
+        self.sid.as_deref().or(self.name.as_deref())
+    }
+
+    pub fn sid(&self) -> Option<&str> {
+        self.sid.as_deref()
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    pub fn action(&self) -> GppGroupAction {
+        self.action
+    }
+
+    pub fn delete_all_users(&self) -> bool {
+        self.delete_all_users
+    }
+
+    pub fn delete_all_groups(&self) -> bool {
+        self.delete_all_groups
+    }
+
+    /// If true, a future applicability layer must evaluate targeting before applying
+    /// this directive; membership must never be applied globally without evaluation.
+    pub fn has_item_level_targeting(&self) -> bool {
+        self.has_item_level_targeting
+    }
+
+    pub fn members(&self) -> &[GppGroupMember] {
+        &self.members
     }
 }
 


### PR DESCRIPTION
## Problem

RustHound-CE parses privilege assignments but does not yet expose local-group membership directives from GPO policy files. This adds the parser foundation for the later collection and applicability work.

Part of #56.

## Approach

Extend the existing pure parsers and typed GPO models. Accept policy bytes as input and return ordered directives with raw identities; perform no network access or graph mutations. Rebased onto upstream `main` at `6c2c61880d19e1bb64491f7e89d5cf3a24809f48`, preserving the integrated Session/SMB module and current ESC8 dependencies.

## Restricted Groups

Parse `[Group Membership]` in `GptTmpl.inf`:

- `__Members` preserves the complete membership configured for the target group.
- `__Memberof` preserves the parent groups that the target must join.
- Keep names, SID strings and leading `*` markers; retain empty assignments and source order.
- Cover multiple principals, named/SID targets, malformed suffixes, missing `=`, comments, CRLF and canonical UTF-16LE input.

## GPP Groups.xml

- Preserve C/D/R/U group actions; absent group action defaults to Update.
- Preserve ADD/REMOVE member actions. Missing, blank or unsupported member actions return `MalformedContent`; no implicit ADD.
- Prefer nonempty group/member SIDs over names. Empty or whitespace-only identities become absent, without trimming meaningful names.
- Omit disabled roots and items. Preserve `deleteAllUsers` and `deleteAllGroups`, defaulting to false when absent.
- Detect `Filters` and retain `has_item_level_targeting`. Future applicability code must evaluate targeting before applying membership globally.
- Check document closure and relevant element ancestry, support prefixed element names, and reject malformed identities/attributes. Unknown subtrees cannot inject membership directives.

## Protocol compliance

Follow [MS-GPSB 2.2.10](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpsb/b73d8bae-ed22-48aa-acba-7065ab52d709) for Restricted Groups and [MS-GPPREF 2.2.1.11.1](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gppref/4b6788a7-c106-4e55-9cfc-1a52bb786e86) for identity precedence and actions. Empty SID fallback also covers the [Microsoft example](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gppref/37722b69-41dd-4813-8bcd-7a1b4d44a13d).

The [Groups schema](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gppref/f1def2c9-81cb-4abb-b1bc-d73ce6b4c82a) places `disabled` on `Groups` and `Group/Properties`; [common attributes](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gppref/55d49337-d652-4268-95b2-cfdf21e99ca4) describe root disabling. Additionally tolerate `Group disabled` to preserve conservative behavior accepted by the initial parser. Case-insensitive action tokens and boolean text values are tolerated; this is a focused parser, not a complete XSD validator.

Keep `quick-xml 0.37.5`: MIT, declared MSRV 1.56, no default features and only the existing `memchr` as a mandatory dependency. No dependency replacement or unrelated lockfile updates.

## Validation

Local Windows x86_64 MSVC, Rust 1.98.0:

- `cargo test --all-targets`: PASS, 95 executions (31 library + 64 binary); includes 21 Groups.xml tests and 5 dedicated Restricted Groups tests.
- `cargo clippy --all-targets -- -A warnings`: PASS.
- `cargo clippy --all-targets`: PASS with existing project warnings; none in the GPO module.
- `cargo build`: PASS.
- `cargo build --release`: PASS (optimized build completed).
- `git diff upstream/main...HEAD --check`: PASS.
- `FMT_GLOBAL=BASELINE_FAIL_ACCEPTED`: `cargo fmt --check` reports formatting differences in 54 files byte-identical to upstream. This existing baseline is explicitly accepted for this focused PR; those files remain unchanged.
- `FMT_CHANGED_FILES=PASS`: `rustfmt --edition 2021 --check` passes for every changed Rust file.
- `make debug`: NOT_RUN; GNU Make is unavailable in the current Windows environment.
- Rust 1.85.0: 44 GPO tests PASS in an isolated validation harness referencing the actual source files with `quick-xml 0.37.5` and `memchr 2.7.5`. This does not claim full-project MSRV validation.
- Linux, Windows GNU and macOS builds: NOT_RUN locally; their target toolchains are unavailable. No hosted CI result is claimed.

## Security considerations

All fixtures are synthetic. The diff passed a redacted Gitleaks scan and manual identity/credential review. Disabled directives never become active memberships, empty SIDs do not override usable names, and unknown member actions cannot imply grants. XML parsing performs no external entity retrieval; DTDs and CDATA are rejected. This change does not execute collected policy.

## Non-goals

No SYSVOL/SMB transport, `gPCFileSysPath`, LDAP retrieval, AD SID resolution, OU/domain/site applicability, security/WMI filtering, targeting evaluation, or AdminTo/CanRDP/ExecuteDCOM/CanPSRemote edge generation. Additional GPP properties such as renaming and current-user operations are not modeled by this parser foundation.

## Follow-up

Integrate read-only policy retrieval separately, then resolve identities and evaluate applicability/targeting before generating graph edges. Keep #56 open for that remaining work.