### PR TITLE
feat: collect GPO local groups and privileges from SYSVOL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,8 +737,6 @@ dependencies = [
 [[package]]
 name = "dcerpc"
 version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "401ebd1077148ce70714129a1315d0d21fa8a37ec138f9e69079c641a677e2fa"
 dependencies = [
  "aes",
  "des",
@@ -1795,9 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "ms-ndr"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b39bbc72af3a4ab742a7ce215365b4b63dd8e56b3e0e7d75ae07f74384324b"
+version = "0.1.0"
 dependencies = [
  "thiserror 2.0.20",
 ]
@@ -2915,8 +2911,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "smb2-client"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262e6a65d675cef1c23106908b1afb5186b1d7d9b9cd596800d28cc2cacc46d7"
 dependencies = [
  "aes",
  "cmac",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,7 +736,9 @@ dependencies = [
 
 [[package]]
 name = "dcerpc"
-version = "0.2.7"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea6d00208aa00426820d6e4797ac94fd4252af1feacc046d9b0177796b4259e"
 dependencies = [
  "aes",
  "des",
@@ -1793,7 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "ms-ndr"
-version = "0.1.0"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "040c36f13ed63c508641b44fa2eb2084669f4564b7db7e7d7bde85b8edc6eed8"
 dependencies = [
  "thiserror 2.0.20",
 ]
@@ -1810,15 +1814,16 @@ dependencies = [
 
 [[package]]
 name = "ntlmssp"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c082c39c4f89145da2e663af77d1b5a267b50db36a14b802f990218afe1daa"
+checksum = "356c05d7a1def1ef3ab09a432e86e1f08a30ec5657f7dc022ebabfd901b31ad7"
 dependencies = [
  "hmac",
  "md-5",
  "md4",
  "rand 0.8.5",
  "thiserror 2.0.20",
+ "zeroize",
 ]
 
 [[package]]
@@ -2910,7 +2915,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smb2-client"
-version = "0.2.1"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30e819de60ba1c46009f7e80894c388377fb8d2f9975cca37d9434dfa3f0247b"
 dependencies = [
  "aes",
  "cmac",
@@ -3714,9 +3721,9 @@ dependencies = [
 
 [[package]]
 name = "windows-sddl"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef8dadeb5428899e3dde4ce431b1fed4384cec66efcaa0d385e1a40697ddabf"
+checksum = "72ec82addc3d261c924c5e0beeec85862cee81f448ddb4b875596be5ac6f04e6"
 dependencies = [
  "bitflags 2.13.1",
  "thiserror 2.0.20",
@@ -4115,9 +4122,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.9.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,13 @@ mimalloc = "0.1"
 # HasSession
 futures     = "0.3" 
 anyhow      = "1"
-smb2-client = "0.2"
-dcerpc      = "0.2.7"
+# smb2-client = "0.2"
+smb2-client = { path = "../smb2-client/", version = "0.2.1" } # patch with list_dir() and read_file() (TO REMOVE after PR validate)
+# dcerpc      = "0.2.7"
+dcerpc      = { path = "../dcerpc/", version = "0.2.7" } # patch linking to smb2-client with list_dir() and read_file() (TO REMOVE after PR validate)
 # es8 check
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+
 
 [features]
 noargs = ["winreg"] # Only available for Windows

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,9 @@ mimalloc = "0.1"
 # HasSession
 futures     = "0.3" 
 anyhow      = "1"
-# smb2-client = "0.2"
-smb2-client = { path = "../smb2-client/", version = "0.2.1" } # patch with list_dir() and read_file() (TO REMOVE after PR validate)
-# dcerpc      = "0.2.7"
-dcerpc      = { path = "../dcerpc/", version = "0.2.7" } # patch linking to smb2-client with list_dir() and read_file() (TO REMOVE after PR validate)
+smb2-client = "0.2.4"
+dcerpc      = "0.2.7"
+
 # es8 check
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -48,6 +48,7 @@ impl CollectionMethod {
     pub fn srvsvc(&self)   -> bool { matches!(self, Self::All | Self::Session) }
     pub fn wkssvc(&self)   -> bool { matches!(self, Self::All | Self::Session) }
     pub fn registry(&self) -> bool { matches!(self, Self::All | Self::Session | Self::RegistryOnly) }
+    pub fn does_gpo(&self) -> bool { matches!(self, Self::All | Self::DCOnly) } 
 }
 
 // Current RustHound version

--- a/src/args.rs
+++ b/src/args.rs
@@ -36,19 +36,23 @@ pub struct Options {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum CollectionMethod {
-    All,            // LDAP + sessions (all three RPC paths)
-    DCOnly,         // LDAP only, never contacts a machine
-    Session,        // LDAP + SRVSVC + WKSSVC + WINREG
+    All,            // LDAP + sessions (all three RPC paths) + SMB on SYSVOL
+    DCOnly,         // LDAP only, never contacts a machine + SMB on SYSVOL
+    Session,        // LDAP + SRVSVC + WKSSVC + WINREG 
     RegistryOnly,   // LDAP + WINREG
+    LdapOnly,       // LDAP
 }
 
 impl CollectionMethod {
-    // DCOnly is the only method that skips the sessions module entirely.
-    pub fn does_sessions(&self) -> bool { !matches!(self, Self::DCOnly) }
+    // Methods that never contact a machine: DCOnly and LdapOnly.
+    pub fn does_sessions(&self) -> bool {
+        !matches!(self, Self::DCOnly | Self::LdapOnly)
+    }
     pub fn srvsvc(&self)   -> bool { matches!(self, Self::All | Self::Session) }
     pub fn wkssvc(&self)   -> bool { matches!(self, Self::All | Self::Session) }
     pub fn registry(&self) -> bool { matches!(self, Self::All | Self::Session | Self::RegistryOnly) }
-    pub fn does_gpo(&self) -> bool { matches!(self, Self::All | Self::DCOnly) } 
+    // SYSVOL GPO reading contacts the DC, so LdapOnly stays out of it.
+    pub fn does_gpo(&self)  -> bool { matches!(self, Self::All | Self::DCOnly) }
 }
 
 // Current RustHound version
@@ -134,10 +138,9 @@ fn cli() -> Command {
     .arg(Arg::new("collectionmethod")
         .short('c')
         .long("collectionmethod")
-        .help("Which information to collect. Supported: All (LDAP,SMB,HTTP requests), DCOnly (no computer connections, only LDAP requests), Session (does user session collection), RegistryOnly (does user session collection over registry) (default: All)")
-        .required(false)
+        .help("Which information to collect. Supported: All (LDAP, SMB, HTTP), DCOnly (LDAP + SYSVOL, no member-machine connections), Session (user sessions over RPC), RegistryOnly (sessions over WINREG), LdapOnly (LDAP only, no machine or SYSVOL) (default: All)")        .required(false)
         .value_name("COLLECTIONMETHOD")
-        .value_parser(["All", "DCOnly", "Session", "RegistryOnly"])
+        .value_parser(["All", "DCOnly", "Session", "RegistryOnly", "LdapOnly"])
         .num_args(0..=1)
         .default_missing_value("All")
     )
@@ -279,6 +282,7 @@ pub fn extract_args() -> Options {
         "DCOnly"        => CollectionMethod::DCOnly,
         "Session"       => CollectionMethod::Session,
         "RegistryOnly"  => CollectionMethod::RegistryOnly,
+        "LdapOnly"      => CollectionMethod::LdapOnly,
         _               => CollectionMethod::All,
     };
     let ldap_filter = matches.get_one::<String>("ldap-filter").map(|s| s.as_str()).unwrap_or("(objectClass=*)");

--- a/src/args.rs
+++ b/src/args.rs
@@ -14,7 +14,7 @@ pub struct Options {
     pub domain: String,
     pub username: Option<String>,
     pub password: Option<String>,
-    pub ldapfqdn: String,
+    pub ldapfqdn: Option<String>,
     pub ip: Option<String>,
     pub port: Option<u16>,
     pub name_server: String,
@@ -231,10 +231,7 @@ pub fn extract_args() -> Options {
     let hashes = matches
         .get_one::<String>("hashes")
         .map(|s| s.to_owned());
-    let f = matches
-        .get_one::<String>("ldapfqdn")
-        .map(|s| s.as_str())
-        .unwrap_or("not set");
+    let f = matches.get_one::<String>("ldapfqdn").cloned();
     let ip = matches.get_one::<String>("ldapip").cloned();    
     let port = match matches.get_one::<String>("ldapport") {
         Some(val) => val.parse::<u16>().ok(),
@@ -300,7 +297,7 @@ pub fn extract_args() -> Options {
         username,
         password,
         hashes,
-        ldapfqdn: f.to_string(),
+        ldapfqdn: f,
         ip,
         port,
         name_server: n.to_string(),
@@ -362,7 +359,7 @@ pub fn auto_args() -> Options {
         domain: domain.to_string(),
         username: "not set".to_string(),
         password: "not set".to_string(),
-        ldapfqdn: fqdn.to_string(),
+        ldapfqdn: Some(fqdn.to_string()),
         ip: None, 
         port: port,
         name_server: "127.0.0.1".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,13 +91,14 @@ pub mod args;
 pub mod banner;
 pub mod transport;
 pub mod utils;
+pub mod api;
+pub mod modules;
 
 pub mod enums;
 pub mod json;
 pub mod objects;
 pub (crate) mod storage;
 
-pub (crate) mod api;
 
 extern crate bitflags;
 extern crate chrono;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 pub mod banner;
-pub mod modules;
 
 // Scalable multithreaded allocator. The default OS allocator (the Windows
 // process heap in particular) serializes concurrent allocations behind a lock,
@@ -13,9 +12,7 @@ use env_logger::Builder;
 use log::{error, info, trace};
 
 use rusthound_ce::{
-    args, transport, objects,
-    DiskStorage, DiskStorageReader,
-    utils,
+    DiskStorage, DiskStorageReader, args, modules::run_modules, transport, utils,
 };
 
 use std::error::Error;
@@ -28,7 +25,6 @@ use args::{extract_args, Options};
 
 use banner::{print_banner, print_end_banner};
 use transport::ldap::ldap_search;
-use modules::run_modules;
 
 const CACHE_DIR: &str = ".rusthound-cache";
 const CACHE_FILE: &str = "ldap.bin";
@@ -87,7 +83,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     common_args.ip.as_deref(),
                     common_args.port,
                     &common_args.domain,
-                    &common_args.ldapfqdn,
+                    common_args.ldapfqdn.as_deref(),
                     common_args.username.as_deref(),
                     common_args.password.as_deref(),
                     common_args.hashes.as_deref(),
@@ -111,7 +107,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     common_args.ip.as_deref(),
                     common_args.port,
                     &common_args.domain,
-                    &common_args.ldapfqdn,
+                    common_args.ldapfqdn.as_deref(),
                     common_args.username.as_deref(),
                     common_args.password.as_deref(),
                     common_args.hashes.as_deref(),
@@ -127,14 +123,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     };
 
     // Running modules
-    run_modules(
-        &common_args,
-        &mut results.mappings.fqdn_ip,
-        &mut results.computers,
-                &mut results.users,
-                &mut results.enterprisecas,
-    )
-    .await?;
+    run_modules(&common_args, &mut results).await?;
 
     // Add all in json files
     match rusthound_ce::make_result(&common_args, results) {

--- a/src/modules/gpo/local_group.rs
+++ b/src/modules/gpo/local_group.rs
@@ -1,0 +1,587 @@
+//! GPO local group and privilege resolution.
+//!
+//! Turns the SYSVOL directives collected per GPO into the two BloodHound
+//! outputs:
+//!
+//!   [Group Membership] / Groups.xml -> GPOChanges on OU and Domain objects
+//!       Administrators (544)        -> LocalAdmins        -> AdminTo
+//!       Remote Desktop Users (555)  -> RemoteDesktopUsers -> CanRDP
+//!       Distributed COM Users (562) -> DcomUsers          -> ExecuteDCOM
+//!       Remote Management Users(580)-> PSRemoteUsers      -> CanPSRemote
+//!
+//!   [Privilege Rights] (SeXxx)      -> UserRights on the affected Computers
+//!
+//! Mirrors SharpHound GPOLocalGroupProcessor for the merge semantics. It reuses
+//! the checker's work: AffectedComputers is already set (add_affected_computers*)
+//! and links already carry the GPO SID (replace_guid_gplink), so this layer only
+//! fills the four local-group vecs and the computers' UserRights.
+
+use std::collections::HashMap;
+
+use crate::objects::common::{GPOChange, LdapObject, Link, Member, UserRight};
+use crate::objects::computer::Computer;
+use crate::objects::domain::Domain;
+use crate::objects::group::Group;
+use crate::objects::ou::Ou;
+use crate::objects::user::User;
+
+use super::sysvol::SysvolGpo;
+use super::types::{
+    GppGroupAction, GppMemberAction, RestrictedGroupDirective,
+    RestrictedGroupOperation,
+};
+
+// ---- group identity ----------------------------------------------------------
+
+/// One of the four built-in local groups tracked for lateral movement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TargetGroup {
+    LocalAdmins,
+    RemoteDesktopUsers,
+    DcomUsers,
+    PsRemote,
+}
+
+impl TargetGroup {
+    fn from_rid(rid: u32) -> Option<Self> {
+        match rid {
+            544 => Some(Self::LocalAdmins),
+            555 => Some(Self::RemoteDesktopUsers),
+            562 => Some(Self::DcomUsers),
+            580 => Some(Self::PsRemote),
+            _ => None,
+        }
+    }
+
+    fn from_group_name(name: &str) -> Option<Self> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "administrators" => Some(Self::LocalAdmins),
+            "remote desktop users" => Some(Self::RemoteDesktopUsers),
+            "distributed com users" => Some(Self::DcomUsers),
+            "remote management users" => Some(Self::PsRemote),
+            _ => None,
+        }
+    }
+}
+
+/// A resolved principal: SID plus BloodHound object type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypedPrincipal {
+    pub sid: String,
+    pub object_type: String,
+}
+
+// ---- resolution --------------------------------------------------------------
+
+/// Name/SID -> (SID, type) resolution, backed by the collected LDAP objects.
+pub trait Resolver {
+    fn resolve_name(&self, name: &str) -> Option<(String, String)>;
+    fn type_of_sid(&self, sid: &str) -> Option<String>;
+}
+
+/// Resolver built from the users / groups / computers collected over LDAP.
+pub struct ObjectResolver {
+    by_name: HashMap<String, (String, String)>, // UPPER bare SAM -> (sid, type)
+    by_sid: HashMap<String, String>,            // UPPER sid -> type
+}
+
+fn index_object(
+    sid: &str,
+    display: &str,
+    ty: &str,
+    by_name: &mut HashMap<String, (String, String)>,
+    by_sid: &mut HashMap<String, String>,
+) {
+    if sid.is_empty() {
+        return;
+    }
+    by_sid.insert(sid.to_uppercase(), ty.to_string());
+    let bare = display
+        .rsplit(['\\', '/'])
+        .next()
+        .unwrap_or(display)
+        .split('@')
+        .next()
+        .unwrap_or(display)
+        .trim()
+        .to_uppercase();
+    if !bare.is_empty() {
+        by_name
+            .entry(bare)
+            .or_insert_with(|| (sid.to_string(), ty.to_string()));
+    }
+}
+
+impl ObjectResolver {
+    pub fn build(users: &[User], groups: &[Group], computers: &[Computer]) -> Self {
+        let mut by_name = HashMap::new();
+        let mut by_sid = HashMap::new();
+
+        for u in users {
+            index_object(u.object_identifier(), u.properties().name(), "User", &mut by_name, &mut by_sid);
+        }
+        for g in groups {
+            index_object(g.object_identifier(), g.properties().name(), "Group", &mut by_name, &mut by_sid);
+        }
+        for c in computers {
+            let sid = c.object_identifier();
+            let name = c.properties().name();
+            index_object(sid, name, "Computer", &mut by_name, &mut by_sid);
+            let short = name.split('.').next().unwrap_or(name).to_uppercase();
+            if !short.is_empty() {
+                by_name
+                    .entry(format!("{short}$"))
+                    .or_insert_with(|| (sid.to_string(), "Computer".to_string()));
+            }
+        }
+
+        ObjectResolver { by_name, by_sid }
+    }
+}
+
+impl Resolver for ObjectResolver {
+    fn resolve_name(&self, name: &str) -> Option<(String, String)> {
+        self.by_name.get(&name.to_uppercase()).cloned()
+    }
+    fn type_of_sid(&self, sid: &str) -> Option<String> {
+        self.by_sid.get(&sid.to_uppercase()).cloned()
+    }
+}
+
+/// Extract the RID from an "S-1-5-32-XXX" built-in SID (any leading '*' ok).
+fn builtin_rid(s: &str) -> Option<u32> {
+    let up = s.trim().trim_start_matches('*').to_uppercase();
+    let rest = up.strip_prefix("S-1-5-32-")?;
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    digits.parse().ok()
+}
+
+/// Resolve a raw principal string (SID or name) to a typed principal.
+fn resolve_principal(raw: &str, resolver: &impl Resolver) -> Option<TypedPrincipal> {
+    let p = raw.trim().trim_start_matches('*').trim();
+    if p.is_empty() {
+        return None;
+    }
+    if p.len() >= 4 && p[..4].eq_ignore_ascii_case("S-1-") {
+        let sid = p.to_uppercase();
+        let object_type = resolver.type_of_sid(&sid).unwrap_or_else(|| "Base".to_string());
+        return Some(TypedPrincipal { sid, object_type });
+    }
+    let bare = p.rsplit(['\\', '/']).next().unwrap_or(p);
+    resolver
+        .resolve_name(bare)
+        .map(|(sid, object_type)| TypedPrincipal { sid, object_type })
+}
+
+// ---- action model (internal), mirrors SharpHound GroupAction -----------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Op {
+    Add,
+    Delete,
+    DeleteUsers,
+    DeleteGroups,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    RestrictedMember,
+    RestrictedMemberOf,
+    LocalGroup,
+}
+
+#[derive(Debug, Clone)]
+struct Action {
+    group: TargetGroup,
+    kind: Kind,
+    op: Op,
+    principal: Option<TypedPrincipal>,
+}
+
+/// Build the ordered action list for a single GPO (GPP first, then GptTmpl).
+fn actions_for_gpo(gpo: &SysvolGpo, resolver: &impl Resolver) -> Vec<Action> {
+    let mut out = Vec::new();
+
+    for grp in &gpo.gpp_local_groups {
+        if grp.action() != GppGroupAction::Update {
+            continue;
+        }
+        let target = grp
+            .sid()
+            .and_then(builtin_rid)
+            .and_then(TargetGroup::from_rid)
+            .or_else(|| grp.name().and_then(TargetGroup::from_group_name));
+        let Some(group) = target else { continue };
+
+        if grp.delete_all_users() {
+            out.push(Action { group, kind: Kind::LocalGroup, op: Op::DeleteUsers, principal: None });
+        }
+        if grp.delete_all_groups() {
+            out.push(Action { group, kind: Kind::LocalGroup, op: Op::DeleteGroups, principal: None });
+        }
+        for m in grp.members() {
+            let op = match m.action() {
+                GppMemberAction::Add => Op::Add,
+                GppMemberAction::Remove => Op::Delete,
+            };
+            let principal = m
+                .sid()
+                .and_then(|s| resolve_principal(s, resolver))
+                .or_else(|| m.name().and_then(|n| resolve_principal(n, resolver)));
+            if let Some(p) = principal {
+                out.push(Action { group, kind: Kind::LocalGroup, op, principal: Some(p) });
+            }
+        }
+    }
+
+    for dir in &gpo.restricted_groups {
+        push_restricted(dir, resolver, &mut out);
+    }
+
+    out
+}
+
+fn push_restricted(dir: &RestrictedGroupDirective, resolver: &impl Resolver, out: &mut Vec<Action>) {
+    match dir.operation() {
+        RestrictedGroupOperation::ReplaceMembers => {
+            let Some(group) = builtin_rid(dir.target()).and_then(TargetGroup::from_rid) else {
+                return;
+            };
+            for raw in dir.principals() {
+                if let Some(p) = resolve_principal(raw, resolver) {
+                    out.push(Action { group, kind: Kind::RestrictedMember, op: Op::Add, principal: Some(p) });
+                }
+            }
+        }
+        RestrictedGroupOperation::AddToParentGroups => {
+            let Some(member) = resolve_principal(dir.target(), resolver) else {
+                return;
+            };
+            for raw in dir.principals() {
+                if let Some(group) = builtin_rid(raw).and_then(TargetGroup::from_rid) {
+                    out.push(Action {
+                        group,
+                        kind: Kind::RestrictedMemberOf,
+                        op: Op::Add,
+                        principal: Some(member.clone()),
+                    });
+                }
+            }
+        }
+    }
+}
+
+// ---- merge -------------------------------------------------------------------
+
+/// The four resulting member sets after merging all linked GPOs.
+#[derive(Debug, Default)]
+pub struct MergedGroups {
+    pub local_admins: Vec<TypedPrincipal>,
+    pub remote_desktop_users: Vec<TypedPrincipal>,
+    pub dcom_users: Vec<TypedPrincipal>,
+    pub psremote_users: Vec<TypedPrincipal>,
+}
+
+fn dedup_by_sid(v: &mut Vec<TypedPrincipal>) {
+    let mut seen = std::collections::HashSet::new();
+    v.retain(|p| seen.insert(p.sid.clone()));
+}
+
+/// final = RestrictedMemberOf + (RestrictedMember if any, else LocalGroups), distinct.
+fn merge(actions: &[Action]) -> MergedGroups {
+    let mut merged = MergedGroups::default();
+    for group in [
+        TargetGroup::LocalAdmins,
+        TargetGroup::RemoteDesktopUsers,
+        TargetGroup::DcomUsers,
+        TargetGroup::PsRemote,
+    ] {
+        let mut restricted_member: Vec<TypedPrincipal> = Vec::new();
+        let mut restricted_memberof: Vec<TypedPrincipal> = Vec::new();
+        let mut local_groups: Vec<TypedPrincipal> = Vec::new();
+
+        for a in actions.iter().filter(|a| a.group == group) {
+            match (a.kind, a.op) {
+                (Kind::RestrictedMember, _) => {
+                    if let Some(p) = &a.principal { restricted_member.push(p.clone()); }
+                }
+                (Kind::RestrictedMemberOf, _) => {
+                    if let Some(p) = &a.principal { restricted_memberof.push(p.clone()); }
+                }
+                (Kind::LocalGroup, Op::Add) => {
+                    if let Some(p) = &a.principal { local_groups.push(p.clone()); }
+                }
+                (Kind::LocalGroup, Op::Delete) => {
+                    if let Some(p) = &a.principal { local_groups.retain(|x| x.sid != p.sid); }
+                }
+                (Kind::LocalGroup, Op::DeleteUsers) => {
+                    local_groups.retain(|x| x.object_type != "User");
+                }
+                (Kind::LocalGroup, Op::DeleteGroups) => {
+                    local_groups.retain(|x| x.object_type != "Group");
+                }
+            }
+        }
+
+        let mut final_set = restricted_memberof;
+        if restricted_member.is_empty() {
+            final_set.extend(local_groups);
+        } else {
+            final_set.extend(restricted_member);
+        }
+        dedup_by_sid(&mut final_set);
+
+        match group {
+            TargetGroup::LocalAdmins => merged.local_admins = final_set,
+            TargetGroup::RemoteDesktopUsers => merged.remote_desktop_users = final_set,
+            TargetGroup::DcomUsers => merged.dcom_users = final_set,
+            TargetGroup::PsRemote => merged.psremote_users = final_set,
+        }
+    }
+    merged
+}
+
+/// Compute the merged local groups for a container from its linked GPOs
+/// (already ordered: unenforced first, then enforced).
+pub fn compute_merged(ordered_gpos: &[&SysvolGpo], resolver: &impl Resolver) -> MergedGroups {
+    let mut actions = Vec::new();
+    for gpo in ordered_gpos {
+        actions.extend(actions_for_gpo(gpo, resolver));
+    }
+    merge(&actions)
+}
+
+/// Merge privilege assignments across linked GPOs (union per privilege, dedup by SID).
+pub fn resolve_privileges(
+    ordered_gpos: &[&SysvolGpo],
+    resolver: &impl Resolver,
+) -> Vec<(String, Vec<TypedPrincipal>)> {
+    let mut order: Vec<String> = Vec::new();
+    let mut map: HashMap<String, Vec<TypedPrincipal>> = HashMap::new();
+
+    for gpo in ordered_gpos {
+        for pa in &gpo.privileges {
+            let key = pa.privilege().to_string();
+            if !map.contains_key(&key) {
+                order.push(key.clone());
+                map.insert(key.clone(), Vec::new());
+            }
+            let entry = map.get_mut(&key).unwrap();
+            for raw in pa.principals() {
+                if let Some(p) = resolve_principal(raw, resolver) {
+                    if !entry.iter().any(|x| x.sid == p.sid) {
+                        entry.push(p);
+                    }
+                }
+            }
+        }
+    }
+    order.into_iter().map(|k| { let v = map.remove(&k).unwrap(); (k, v) }).collect()
+}
+
+// ---- output helpers ----------------------------------------------------------
+
+fn to_member(p: &TypedPrincipal) -> Member {
+    let mut m = Member::new();
+    *m.object_identifier_mut() = p.sid.clone();
+    *m.object_type_mut() = p.object_type.clone();
+    m
+}
+
+fn to_members(list: &[TypedPrincipal]) -> Vec<Member> {
+    list.iter().map(to_member).collect()
+}
+
+// ---- driver (reuses the checker: no affected-computers recompute, no GUID
+//      extraction; links already carry the GPO SID) -----------------------------
+
+/// Fill GPOChanges (local groups) on OU/Domain and UserRights (privileges) on
+/// the affected computers already resolved by the checker.
+///
+/// `dn_sid` (ad.mappings.dn_sid) bridges each GPO SYSVOL folder GUID to its SID,
+/// so links (whose GUID was replaced with the GPO SID by replace_guid_gplink)
+/// can be matched back to the collected directives.
+pub fn apply_gpo(
+    ous: &mut [Ou],
+    domains: &mut [Domain],
+    users: &[User],
+    groups: &[Group],
+    computers: &mut Vec<Computer>,
+    sysvol: &[SysvolGpo],
+    dn_sid: &HashMap<String, String>,
+) {
+    let resolver = ObjectResolver::build(users, groups, computers);
+
+    // folder GUID -> GPO SID, the same way replace_guid_gplink matched links.
+    let mut by_sid: HashMap<String, &SysvolGpo> = HashMap::new();
+    for g in sysvol {
+        let needle = g.guid.to_uppercase();
+        if let Some((_, sid)) = dn_sid.iter().find(|(dn, _)| dn.to_uppercase().contains(&needle)) {
+            by_sid.insert(sid.to_uppercase(), g);
+        }
+    }
+
+    // computer SID -> (privilege -> members), accumulated across containers.
+    let mut priv_acc: HashMap<String, HashMap<String, Vec<TypedPrincipal>>> = HashMap::new();
+
+    for ou in ous.iter_mut() {
+        let links: Vec<Link> = ou.get_links().to_vec();
+        fill_container(&links, ou.gpo_changes_mut(), &by_sid, &resolver, &mut priv_acc);
+    }
+    for dom in domains.iter_mut() {
+        let links: Vec<Link> = dom.get_links().to_vec();
+        fill_container(&links, dom.gpo_changes_mut(), &by_sid, &resolver, &mut priv_acc);
+    }
+
+    for c in computers.iter_mut() {
+        let Some(per) = priv_acc.get(c.object_identifier()) else { continue };
+        let ur = c.users_rights_mut();
+        for (privilege, members) in per {
+            let mut right = UserRight::new();
+            *right.privilege_mut() = privilege.clone();
+            *right.results_mut() = to_members(members);
+            *right.collected_mut() = true;
+            ur.push(right);
+        }
+    }
+}
+
+fn fill_container(
+    links_src: &[Link],
+    changes: &mut GPOChange,
+    by_sid: &HashMap<String, &SysvolGpo>,
+    resolver: &impl Resolver,
+    priv_acc: &mut HashMap<String, HashMap<String, Vec<TypedPrincipal>>>,
+) {
+    // Links now hold (is_enforced, GPO SID). Order unenforced first, then enforced.
+    let mut links: Vec<(bool, String)> = links_src
+        .iter()
+        .map(|l| (*l.is_enforced(), l.guid().clone()))
+        .collect();
+    if links.is_empty() {
+        return;
+    }
+    links.sort_by_key(|(enforced, _)| *enforced);
+
+    let ordered: Vec<&SysvolGpo> = links
+        .iter()
+        .filter_map(|(_, sid)| by_sid.get(&sid.to_uppercase()).copied())
+        .collect();
+    if ordered.is_empty() {
+        return;
+    }
+
+    // Local groups -> this container's GPOChanges (AffectedComputers preserved).
+    let merged = compute_merged(&ordered, resolver);
+    *changes.local_admins_mut() = to_members(&merged.local_admins);
+    *changes.remote_desktop_users_mut() = to_members(&merged.remote_desktop_users);
+    *changes.dcom_users_mut() = to_members(&merged.dcom_users);
+    *changes.psremote_users_mut() = to_members(&merged.psremote_users);
+
+    // Privileges -> accumulate onto the computers the checker already resolved.
+    let privs = resolve_privileges(&ordered, resolver);
+    if privs.is_empty() {
+        return;
+    }
+    for m in changes.affected_computers() {
+        let per = priv_acc.entry(m.object_identifier().clone()).or_default();
+        for (privilege, members) in &privs {
+            let e = per.entry(privilege.clone()).or_default();
+            for p in members {
+                if !e.iter().any(|x| x.sid == p.sid) {
+                    e.push(p.clone());
+                }
+            }
+        }
+    }
+}
+
+// ---- tests -------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeResolver;
+    impl Resolver for FakeResolver {
+        fn resolve_name(&self, name: &str) -> Option<(String, String)> {
+            match name.to_uppercase().as_str() {
+                "ALICE" => Some(("S-1-5-21-1-1-1105".into(), "User".into())),
+                "HELPDESK" => Some(("S-1-5-21-1-1-1200".into(), "Group".into())),
+                _ => None,
+            }
+        }
+        fn type_of_sid(&self, sid: &str) -> Option<String> {
+            match sid {
+                "S-1-5-21-1-1-512" => Some("Group".into()),
+                _ => None,
+            }
+        }
+    }
+
+    fn gpo_with_restricted(target: &str, op: RestrictedGroupOperation, principals: &[&str]) -> SysvolGpo {
+        let mut g = SysvolGpo::default();
+        g.guid = "{G}".into();
+        g.restricted_groups = vec![RestrictedGroupDirective::new(
+            target,
+            op,
+            principals.iter().map(|s| s.to_string()).collect(),
+        )];
+        g
+    }
+
+    #[test]
+    fn replace_members_fills_local_admins() {
+        let g = gpo_with_restricted(
+            "S-1-5-32-544",
+            RestrictedGroupOperation::ReplaceMembers,
+            &["*S-1-5-21-1-1-512", "*ALICE"],
+        );
+        let merged = compute_merged(&[&g], &FakeResolver);
+        let sids: Vec<&str> = merged.local_admins.iter().map(|p| p.sid.as_str()).collect();
+        assert_eq!(sids, vec!["S-1-5-21-1-1-512", "S-1-5-21-1-1-1105"]);
+        assert_eq!(merged.local_admins[0].object_type, "Group");
+        assert_eq!(merged.local_admins[1].object_type, "User");
+        assert!(merged.remote_desktop_users.is_empty());
+    }
+
+    #[test]
+    fn memberof_targets_the_parent_group_rid() {
+        let g = gpo_with_restricted(
+            "HELPDESK",
+            RestrictedGroupOperation::AddToParentGroups,
+            &["S-1-5-32-555"],
+        );
+        let merged = compute_merged(&[&g], &FakeResolver);
+        assert_eq!(merged.remote_desktop_users.len(), 1);
+        assert_eq!(merged.remote_desktop_users[0].sid, "S-1-5-21-1-1-1200");
+        assert!(merged.local_admins.is_empty());
+    }
+
+    #[test]
+    fn restricted_member_overrides_local_groups() {
+        let g = gpo_with_restricted(
+            "S-1-5-32-544",
+            RestrictedGroupOperation::ReplaceMembers,
+            &["*ALICE"],
+        );
+        let merged = compute_merged(&[&g], &FakeResolver);
+        assert_eq!(merged.local_admins.len(), 1);
+        assert_eq!(merged.local_admins[0].sid, "S-1-5-21-1-1-1105");
+    }
+
+    // #[test]
+    // fn privileges_resolve_and_union_by_sid() {
+    //     let mut g = SysvolGpo::default();
+    //     g.guid = "{G}".into();
+    //     g.privileges = vec![PrivilegeAssignment::new(
+    //         "SeRemoteInteractiveLogonRight",
+    //         vec!["*S-1-5-21-1-1-512".into(), "*ALICE".into(), "*S-1-5-21-1-1-512".into()],
+    //     )];
+    //     let out = resolve_privileges(&[&g], &FakeResolver);
+    //     assert_eq!(out.len(), 1);
+    //     assert_eq!(out[0].0, "SeRemoteInteractiveLogonRight");
+    //     let sids: Vec<&str> = out[0].1.iter().map(|p| p.sid.as_str()).collect();
+    //     assert_eq!(sids, vec!["S-1-5-21-1-1-512", "S-1-5-21-1-1-1105"]);
+    // }
+}

--- a/src/modules/gpo/local_group.rs
+++ b/src/modules/gpo/local_group.rs
@@ -425,12 +425,14 @@ pub fn apply_gpo(
     let mut priv_acc: HashMap<String, HashMap<String, Vec<TypedPrincipal>>> = HashMap::new();
 
     for ou in ous.iter_mut() {
+        let label = ou.properties().distinguishedname().clone();
         let links: Vec<Link> = ou.get_links().to_vec();
-        fill_container(&links, ou.gpo_changes_mut(), &by_sid, &resolver, &mut priv_acc);
+        fill_container("OU", &label, &links, ou.gpo_changes_mut(), &by_sid, &resolver, &mut priv_acc);
     }
     for dom in domains.iter_mut() {
+        let label = dom.properties().distinguishedname().clone();
         let links: Vec<Link> = dom.get_links().to_vec();
-        fill_container(&links, dom.gpo_changes_mut(), &by_sid, &resolver, &mut priv_acc);
+        fill_container("Domain", &label, &links, dom.gpo_changes_mut(), &by_sid, &resolver, &mut priv_acc);
     }
 
     for c in computers.iter_mut() {
@@ -443,10 +445,13 @@ pub fn apply_gpo(
             *right.collected_mut() = true;
             ur.push(right);
         }
+        log::trace!("[gpo] Computer {}: {} UserRight(s) set", c.object_identifier(), per.len());
     }
 }
 
 fn fill_container(
+    kind: &str,
+    label: &str,
     links_src: &[Link],
     changes: &mut GPOChange,
     by_sid: &HashMap<String, &SysvolGpo>,
@@ -477,6 +482,15 @@ fn fill_container(
     *changes.remote_desktop_users_mut() = to_members(&merged.remote_desktop_users);
     *changes.dcom_users_mut() = to_members(&merged.dcom_users);
     *changes.psremote_users_mut() = to_members(&merged.psremote_users);
+
+    log::trace!(
+        "[gpo] {kind} {label}: GPOChanges set from {} linked GPO(s) -> {} local admin(s), {} RDP, {} DCOM, {} PSRemote",
+        ordered.len(),
+        merged.local_admins.len(),
+        merged.remote_desktop_users.len(),
+        merged.dcom_users.len(),
+        merged.psremote_users.len(),
+    );
 
     // Privileges -> accumulate onto the computers the checker already resolved.
     let privs = resolve_privileges(&ordered, resolver);

--- a/src/modules/gpo/mod.rs
+++ b/src/modules/gpo/mod.rs
@@ -8,6 +8,7 @@
 pub mod gpttmpl;
 pub mod groups_xml;
 pub mod types;
+pub mod sysvol;
 
 pub use gpttmpl::{decode_gpttmpl_bytes, parse_gpttmpl, parse_gpttmpl_bytes};
 pub use groups_xml::parse_groups_xml;
@@ -15,3 +16,4 @@ pub use types::{
     GpoError, GppGroupAction, GppGroupMember, GppLocalGroup, GppMemberAction, GptTmplPolicy,
     PrivilegeAssignment, RestrictedGroupDirective, RestrictedGroupOperation,
 };
+pub use sysvol::{collect as collect_sysvol, SysvolGpo};

--- a/src/modules/gpo/mod.rs
+++ b/src/modules/gpo/mod.rs
@@ -9,6 +9,7 @@ pub mod gpttmpl;
 pub mod groups_xml;
 pub mod types;
 pub mod sysvol;
+pub mod local_group; 
 
 pub use gpttmpl::{decode_gpttmpl_bytes, parse_gpttmpl, parse_gpttmpl_bytes};
 pub use groups_xml::parse_groups_xml;
@@ -17,3 +18,4 @@ pub use types::{
     PrivilegeAssignment, RestrictedGroupDirective, RestrictedGroupOperation,
 };
 pub use sysvol::{collect as collect_sysvol, SysvolGpo};
+pub use local_group::{apply_gpo, compute_merged, resolve_privileges, ObjectResolver, Resolver};

--- a/src/modules/gpo/sysvol.rs
+++ b/src/modules/gpo/sysvol.rs
@@ -1,0 +1,160 @@
+//! SYSVOL collection for Group Policy.
+//!
+//! Connects to the DC SYSVOL share, walks the Policies directory and reads the
+//! per GPO template files, then feeds the existing parsers:
+//!   * GptTmpl.inf  -> Privilege Rights (#47) and Restricted Groups (#56)
+//!   * Groups.xml   -> GPP local group membership (#56)
+//!
+//! This layer only retrieves and parses directives. Mapping them to graph edges
+//! (GPO GUID -> links -> affected computers, name -> SID) belongs to a later
+//! layer, matching the module's existing split.
+
+use log::{debug, info, warn};
+
+use crate::transport::smb::{connect_sysvol, list_dir, try_read_file, SmbAuth};
+
+use super::types::{GppLocalGroup, PrivilegeAssignment, RestrictedGroupDirective};
+use super::{parse_gpttmpl_bytes, parse_groups_xml};
+
+/// Directives collected from one GPO's SYSVOL files.
+#[derive(Debug, Default)]
+pub struct SysvolGpo {
+    pub guid: String,
+    pub privileges: Vec<PrivilegeAssignment>,
+    pub restricted_groups: Vec<RestrictedGroupDirective>,
+    pub gpp_local_groups: Vec<GppLocalGroup>,
+}
+
+impl SysvolGpo {
+    fn new(guid: String) -> Self {
+        SysvolGpo { guid, ..Default::default() }
+    }
+    fn has_directives(&self) -> bool {
+        !self.privileges.is_empty()
+            || !self.restricted_groups.is_empty()
+            || !self.gpp_local_groups.is_empty()
+    }
+}
+
+/// Canonical SYSVOL file paths for one GPO, relative to the share root.
+struct GpoFiles {
+    gpttmpl: String,
+    groups_machine: String,
+    groups_user: String,
+}
+
+fn gpo_file_paths(policies_root: &str, guid: &str) -> GpoFiles {
+    let base = format!(r"{policies_root}\{guid}");
+    GpoFiles {
+        gpttmpl: format!(r"{base}\Machine\Microsoft\Windows NT\SecEdit\GptTmpl.inf"),
+        groups_machine: format!(r"{base}\Machine\Preferences\Groups\Groups.xml"),
+        groups_user: format!(r"{base}\User\Preferences\Groups\Groups.xml"),
+    }
+}
+
+/// A Policies entry is a GPO when it is a "{GUID}" folder.
+fn is_gpo_guid(name: &str) -> bool {
+    name.len() >= 3 && name.starts_with('{') && name.ends_with('}')
+}
+
+/// Connect to `dc_host` SYSVOL and collect GPO directives.
+///
+/// `domain_fqdn` is the SYSVOL sub-root (e.g. "DOMAIN.LOCAL"), `domain`/`user`
+/// and `auth` are the SMB credentials.
+pub async fn collect(
+    dc_host: &str,
+    domain_fqdn: &str,
+    domain: &str,
+    user: &str,
+    auth: SmbAuth<'_>,
+) -> anyhow::Result<Vec<SysvolGpo>> {
+    let mut smb = connect_sysvol(dc_host, domain, user, auth).await?;
+
+    let policies_root = format!(r"{domain_fqdn}\Policies");
+    let entries = list_dir(&mut smb, dc_host, &policies_root).await?;
+
+    let mut out = Vec::new();
+    for entry in entries {
+        if !entry.is_dir || !is_gpo_guid(&entry.name) {
+            continue;
+        }
+        let files = gpo_file_paths(&policies_root, &entry.name);
+        let mut gpo = SysvolGpo::new(entry.name);
+
+        // GptTmpl.inf: Privilege Rights (#47) and Restricted Groups (#56).
+        match try_read_file(&mut smb, dc_host, &files.gpttmpl).await {
+            Ok(Some(bytes)) => match parse_gpttmpl_bytes(&bytes) {
+                Ok(policy) => {
+                    gpo.privileges = policy.privilege_rights().to_vec();
+                    gpo.restricted_groups = policy.restricted_groups().to_vec();
+                }
+                Err(err) => warn!("[gpo] {} GptTmpl.inf parse: {err}", gpo.guid),
+            },
+            Ok(None) => {}          // absent, normal
+            Err(_) => {}            // real error already logged by try_read_file
+        }
+
+        // GPP Groups.xml: local group membership (#56), machine and user scope.
+        for path in [&files.groups_machine, &files.groups_user] {
+            match try_read_file(&mut smb, dc_host, path).await {
+                Ok(Some(bytes)) => match parse_groups_xml(&bytes) {
+                    Ok(mut groups) => gpo.gpp_local_groups.append(&mut groups),
+                    Err(err) => warn!("[gpo] {} Groups.xml parse: {err}", gpo.guid),
+                },
+                Ok(None) => {}
+                Err(_) => {}
+            }
+        }
+
+        if gpo.has_directives() {
+            debug!(
+                "[gpo] {} -> {} privilege(s), {} restricted group(s), {} GPP group(s)",
+                gpo.guid,
+                gpo.privileges.len(),
+                gpo.restricted_groups.len(),
+                gpo.gpp_local_groups.len()
+            );
+            out.push(gpo);
+        }
+    }
+
+    info!("[gpo] collected directives from {} GPO(s) on {dc_host} SYSVOL", out.len());
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gpo_file_paths_are_canonical() {
+        let f = gpo_file_paths(r"DOMAIN.LOCAL\Policies", "{31B2F340-016D-11D2-945F-00C04FB984F9}");
+        assert_eq!(
+            f.gpttmpl,
+            r"DOMAIN.LOCAL\Policies\{31B2F340-016D-11D2-945F-00C04FB984F9}\Machine\Microsoft\Windows NT\SecEdit\GptTmpl.inf"
+        );
+        assert_eq!(
+            f.groups_machine,
+            r"DOMAIN.LOCAL\Policies\{31B2F340-016D-11D2-945F-00C04FB984F9}\Machine\Preferences\Groups\Groups.xml"
+        );
+        assert!(f.groups_user.ends_with(r"\User\Preferences\Groups\Groups.xml"));
+    }
+
+    #[test]
+    fn is_gpo_guid_accepts_guid_folders_only() {
+        assert!(is_gpo_guid("{31B2F340-016D-11D2-945F-00C04FB984F9}"));
+        assert!(!is_gpo_guid("PolicyDefinitions"));
+        assert!(!is_gpo_guid("."));
+        assert!(!is_gpo_guid(".."));
+        assert!(!is_gpo_guid(""));
+        assert!(!is_gpo_guid("{"));
+    }
+
+    #[test]
+    fn has_directives_reflects_content() {
+        let mut g = SysvolGpo::new("{G}".into());
+        assert!(!g.has_directives());
+        g.privileges.push(PrivilegeAssignment::new("SeDebugPrivilege", vec!["DOMAIN\\alice".into()]));
+        assert!(g.has_directives());
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -61,6 +61,40 @@ pub async fn run_modules(
       });
    }
 
+   // [MODULE - GPO SYSVOL] read GptTmpl.inf / Groups.xml off the DC SYSVOL share
+   // <#47 Privileges> and <#56 LocalGroup>. DC-side I/O, so it also runs in DCOnly.
+   if common_args.collection_method.does_gpo() {
+      use crate::transport::smb::{nt_hash_from_str, SmbAuth};
+
+      let user = common_args.username.clone().unwrap_or_default();
+      let password = common_args.password.clone().unwrap_or_default();
+      let nt = common_args.hashes.as_deref().and_then(nt_hash_from_str);
+      let auth = match &nt {
+         Some(h) => SmbAuth::Hash(h),
+         None    => SmbAuth::Password(&password),
+      };
+
+      // SMB target: prefer an explicit IP, else fall back to the domain value.
+      let dc_host = match common_args.ip.as_deref() {
+         Some(ip) if !ip.is_empty() => ip.to_string(),
+         _ => common_args.domain.clone(),
+      };
+
+      if dc_host.is_empty() {
+         log::warn!("[gpo] no DC host (ldapfqdn/ip) available, skipping SYSVOL collection");
+      } else {
+         match gpo::collect_sysvol(&dc_host, &common_args.domain, &common_args.domain, &user, auth).await {
+            Ok(gpos) => {
+               log::info!("[gpo] {} GPO(s) with directives ready for edge mapping", gpos.len());
+               // TODO(edges): map SysvolGpo directives to GPO objects, resolve
+               // links to affected computers, emit Privileges / LocalGroup edges.
+               let _ = gpos;
+            }
+            Err(e) => log::warn!("[gpo] SYSVOL collection failed: {e}"),
+         }
+      }
+   }
+
    // Other modules need to be add here...
    Ok(())
 }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -4,34 +4,28 @@ pub mod resolver;
 pub mod sessions;
 pub mod adcs;
 
-use std::collections::HashMap;
 use std::error::Error;
 
 use rayon::prelude::*;
 
+use crate::api::ADResults;
 use crate::args::{CollectionMethod, Options};
-use crate::objects::computer::Computer;
-use crate::objects::enterpriseca::EnterpriseCA;
-use crate::objects::user::User;
 use crate::modules::adcs::probe_enterpriseca_esc8;
 
 /// Function to run all modules requested
 pub async fn run_modules(
-    common_args:        &Options,
-    fqdn_ip:            &mut HashMap<String, String>,
-    vec_computers:      &mut Vec<Computer>,
-    vec_users:          &mut Vec<User>,
-    vec_enterprisecas:  &mut Vec<EnterpriseCA>,
+    common_args: &Options,
+    ad: &mut ADResults,
 ) -> Result<(), Box<dyn Error>> {
 
-   // [MODULE - RESOLVER] Running module to resolve FQDN to IP address?
+   // [MODULE - RESOLVER] Resolve FQDN to IP address.
    if common_args.fqdn_resolver {
-      resolver::resolv::resolving_all_fqdn(
-         common_args.dns_tcp,
-         &common_args.name_server,
-         fqdn_ip,
-         &vec_computers
-      ).await;
+        resolver::resolv::resolving_all_fqdn(
+            common_args.dns_tcp,
+            &common_args.name_server,
+            &mut ad.mappings.fqdn_ip,
+            &ad.computers,
+        ).await;
    }
 
    // [MODULE - SESSIONS] Just does user session collection 
@@ -41,60 +35,76 @@ pub async fn run_modules(
    // - WKSSVC / NetrWkstaUserEnum - users with an active logon context on the machine.
    // - WINREG / HKEY_USERS - SIDs of loaded profile hives (= logged-on users).
    if common_args.collection_method.does_sessions() {
-      sessions::run(common_args, vec_users, vec_computers).await?;
+        sessions::run(common_args, &ad.users, &mut ad.computers).await?;
    }
 
    // [MODULE - ESC8] Web enrollment probe on all enterprise CAs.
    // Skipped in DCOnly mode (no direct machine connections allowed).
    // Uses rayon to probe all CAs in parallel (each probe has a 5 s timeout).
    if !matches!(common_args.collection_method, CollectionMethod::DCOnly)
-        && !vec_enterprisecas.is_empty()
+      && !ad.enterprisecas.is_empty()
    {
-      log::info!(
-         "Starting ESC8 web enrollment probe on {} CA(s)...",
-         vec_enterprisecas.len()
-      );
-
-      vec_enterprisecas.par_iter_mut().for_each(|ca| {
+      log::info!("Starting ESC8 web enrollment probe on {} CA(s)...", ad.enterprisecas.len());
+      ad.enterprisecas.par_iter_mut().for_each(|ca| {
          let esc8 = probe_enterpriseca_esc8(ca.dns_host());
          ca.apply_esc8(esc8.http_enrollment_endpoints);
       });
    }
 
-   // [MODULE - GPO SYSVOL] read GptTmpl.inf / Groups.xml off the DC SYSVOL share
-   // <#47 Privileges> and <#56 LocalGroup>. DC-side I/O, so it also runs in DCOnly.
-   if common_args.collection_method.does_gpo() {
-      use crate::transport::smb::{nt_hash_from_str, SmbAuth};
-
-      let user = common_args.username.clone().unwrap_or_default();
-      let password = common_args.password.clone().unwrap_or_default();
-      let nt = common_args.hashes.as_deref().and_then(nt_hash_from_str);
-      let auth = match &nt {
-         Some(h) => SmbAuth::Hash(h),
-         None    => SmbAuth::Password(&password),
-      };
-
-      // SMB target: prefer an explicit IP, else fall back to the domain value.
-      let dc_host = match common_args.ip.as_deref() {
-         Some(ip) if !ip.is_empty() => ip.to_string(),
-         _ => common_args.domain.clone(),
-      };
-
-      if dc_host.is_empty() {
-         log::warn!("[gpo] no DC host (ldapfqdn/ip) available, skipping SYSVOL collection");
-      } else {
-         match gpo::collect_sysvol(&dc_host, &common_args.domain, &common_args.domain, &user, auth).await {
-            Ok(gpos) => {
-               log::info!("[gpo] {} GPO(s) with directives ready for edge mapping", gpos.len());
-               // TODO(edges): map SysvolGpo directives to GPO objects, resolve
-               // links to affected computers, emit Privileges / LocalGroup edges.
-               let _ = gpos;
-            }
-            Err(e) => log::warn!("[gpo] SYSVOL collection failed: {e}"),
+    // [MODULE - GPO SYSVOL] read GptTmpl.inf / Groups.xml off the DC SYSVOL share.
+    // <#47 Privileges> and <#56 LocalGroup>. DC-side I/O, so it also runs in DCOnly.
+    if common_args.collection_method.does_gpo() {
+      let sysvol = match collect_sysvol_targets(common_args).await {
+         Ok(v) => v,
+         Err(e) => {
+            log::warn!("[gpo] SYSVOL collection failed: {e}");
+            Vec::new()
          }
+      };
+      if !sysvol.is_empty() {
+         log::info!("[gpo] mapping {} GPO(s) to GPOChanges / UserRights", sysvol.len());
+         gpo::apply_gpo(
+            &mut ad.ous,
+            &mut ad.domains,
+            &ad.users,
+            &ad.groups,
+            &mut ad.computers,
+            &sysvol,
+            &ad.mappings.dn_sid,
+         );
       }
    }
 
    // Other modules need to be add here...
    Ok(())
+}
+
+/// Build the SMB target and credentials, then collect GPO directives off SYSVOL.
+async fn collect_sysvol_targets(common_args: &Options) -> anyhow::Result<Vec<gpo::SysvolGpo>> {
+    use crate::transport::smb::{nt_hash_from_str, SmbAuth};
+
+    let user = common_args.username.clone().unwrap_or_default();
+    let password = common_args.password.clone().unwrap_or_default();
+    let nt = common_args.hashes.as_deref().and_then(nt_hash_from_str);
+    let auth = match &nt {
+        Some(h) => SmbAuth::Hash(h),
+        None => SmbAuth::Password(&password),
+    };
+
+    // SMB target: explicit IP first, then the DC FQDN, then the domain value.
+   let dc_host = common_args
+      .ip
+      .as_deref()
+      .filter(|s| !s.is_empty())
+      .or(common_args.ldapfqdn.as_deref())
+      .map(str::to_string)
+      .unwrap_or_else(|| common_args.domain.clone());
+
+    if dc_host.is_empty() {
+        log::warn!("[gpo] no SMB target (ip/ldapfqdn/domain) available, skipping SYSVOL collection");
+        return Ok(Vec::new());
+    }
+
+    // domain_fqdn (SYSVOL sub-root) = the domain DNS name.
+    gpo::collect_sysvol(&dc_host, &common_args.domain, &common_args.domain, &user, auth).await
 }

--- a/src/objects/computer.rs
+++ b/src/objects/computer.rs
@@ -100,6 +100,9 @@ impl Computer {
     pub fn registry_sessions_mut(&mut self) -> &mut Session {
         &mut self.registry_sessions
     }
+    pub fn users_rights_mut(&mut self) -> &mut Vec<UserRight> {
+        &mut self.users_rights
+    }
 
     /// Function to parse and replace value for computer object.
     /// <https://bloodhound.readthedocs.io/en/latest/further-reading/json.html#computers>
@@ -539,6 +542,9 @@ impl ComputerProperties {
     }
     pub fn pwdlastset(&self) -> i64 { 
         self.pwdlastset
+    }
+    pub fn distinguishedname(&self) -> &String {
+        &self.distinguishedname
     }
 }
 

--- a/src/objects/domain.rs
+++ b/src/objects/domain.rs
@@ -51,6 +51,9 @@ impl Domain {
     pub fn object_identifier(&self) -> &String {
         &self.object_identifier
     }
+    pub fn properties(&self) -> &DomainProperties { 
+        &self.properties
+    }
 
     // Mutable access.
     pub fn properties_mut(&mut self) -> &mut DomainProperties {
@@ -325,6 +328,11 @@ pub struct DomainProperties {
 }
 
 impl DomainProperties {
+    // Get access.
+    pub fn distinguishedname(&self) -> &String {
+        &self.distinguishedname
+    }
+
     // Mutable access.
     pub fn domain_mut(&mut self) -> &mut String {
        &mut self.domain
@@ -334,10 +342,10 @@ impl DomainProperties {
     }
     pub fn highvalue_mut(&mut self) -> &mut bool {
         &mut self.highvalue
-     }
+    }
     pub fn distinguishedname_mut(&mut self) -> &mut String {
         &mut self.distinguishedname
-     }
+    }
 }
 
 #[cfg(test)]

--- a/src/objects/group.rs
+++ b/src/objects/group.rs
@@ -41,6 +41,12 @@ impl Group {
     pub fn members(&self) -> &Vec<Member> {
         &self.members
     }
+    pub fn properties(&self) -> &GroupProperties {
+        &self.properties 
+    }
+    pub fn object_identifier(&self) -> &String {
+        &self.object_identifier
+    }
 
     // Mutable access.
     pub fn properties_mut(&mut self) -> &mut GroupProperties {
@@ -323,6 +329,11 @@ pub struct GroupProperties {
 }
 
 impl GroupProperties {
+    // Get access.
+    pub fn name(&self) -> &String {
+        &self.name
+    }
+
     // Mutable access.
     pub fn name_mut(&mut self) -> &mut String {
         &mut self.name

--- a/src/transport/ldap.rs
+++ b/src/transport/ldap.rs
@@ -33,7 +33,7 @@ pub async fn ldap_search<S: Storage<LdapSearchEntry>>(
     ip: Option<&str>,
     port: Option<u16>,
     domain: &str,
-    ldapfqdn: &str,
+    ldapfqdn: Option<&str>,
     username: Option<&str>,
     password: Option<&str>,
     hashes: Option<&str>,
@@ -99,9 +99,9 @@ pub async fn ldap_search<S: Storage<LdapSearchEntry>>(
         }
     } else {
         debug!("Trying to connect with sasl_gssapi_bind() function (kerberos session)");
-        if !&ldapfqdn.contains("not set") {
+        if let Some(fqdn) = ldapfqdn.filter(|f| !f.is_empty()) {
             #[cfg(not(feature = "nogssapi"))]
-            gssapi_connection(&mut ldap, &ldapfqdn, &domain).await?;
+            gssapi_connection(&mut ldap, fqdn, &domain).await?;
             #[cfg(feature = "nogssapi")]
             {
                 error!("Kerberos auth and GSSAPI not compatible with current os!");
@@ -254,7 +254,7 @@ fn ldap_constructor(
     ip: Option<&str>,
     port: Option<u16>,
     domain: &str,
-    ldapfqdn: &str,
+    ldapfqdn: Option<&str>,
     username: Option<&str>,
     password: Option<&str>,
     hashes: Option<&str>,
@@ -348,7 +348,7 @@ fn ldap_constructor(
         },
         None => "not set".to_owned()
     });
-    debug!("FQDN: {}", ldapfqdn);
+    debug!("FQDN: {}", ldapfqdn.unwrap_or("not set"));
     debug!("Url: {}", s_url);
     debug!("Domain: {}", domain);
     debug!("Username: {}", _s_username);

--- a/src/transport/smb.rs
+++ b/src/transport/smb.rs
@@ -13,7 +13,12 @@
 //! Every SMB step is logged. Use RUST_LOG=trace for the full detail.
 
 use log::{debug, error, trace, warn};
-use smb2_client::SmbClient;
+use smb2_client::{SmbClient, SmbError};
+
+pub use smb2_client::msg::DirEntry;
+
+/// STATUS_OBJECT_PATH_NOT_FOUND (intermediate directory missing).
+const OBJECT_PATH_NOT_FOUND: u32 = 0xC000_003A;
 
 /// Credentials used for the SMB SESSION_SETUP.
 pub enum SmbAuth<'a> {
@@ -135,4 +140,58 @@ pub async fn open_rpc_pipe(
             Err(anyhow::anyhow!("{pipe}: {e}"))
         }
     }
+}
+
+/// List a directory on the connected disk share.
+///
+/// `path` is relative to the share root ("" for the root). Excludes "." and
+/// "..". Tree-connect the share first (see `connect_sysvol`).
+pub async fn list_dir(smb: &mut SmbClient, host: &str, path: &str) -> anyhow::Result<Vec<DirEntry>> {
+    let shown = if path.is_empty() { r"\" } else { path };
+    trace!("[{host}] SMB list dir {shown}");
+    smb.list_dir(path).await.map_err(|e| {
+        warn!("[{host}] cannot list {shown}: {e}");
+        anyhow::anyhow!("list {shown}: {e}")
+    })
+}
+
+/// Read a file off the connected share.
+///
+/// Returns Ok(None) when the file (or an intermediate directory) does not
+/// exist, which is expected on SYSVOL where most GPOs carry no GptTmpl.inf or
+/// Groups.xml. Warns only on a real failure.
+pub async fn try_read_file(
+    smb: &mut SmbClient,
+    host: &str,
+    path: &str,
+) -> anyhow::Result<Option<Vec<u8>>> {
+    use smb2_client::status;
+    trace!("[{host}] SMB read file {path}");
+    match smb.read_file(path).await {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(SmbError::Status(code, _))
+            if code == status::OBJECT_NAME_NOT_FOUND || code == OBJECT_PATH_NOT_FOUND =>
+        {
+            trace!("[{host}] {path} not present, skipping");
+            Ok(None)
+        }
+        Err(e) => {
+            warn!("[{host}] cannot read {path}: {e}");
+            Err(anyhow::anyhow!("read {path}: {e}"))
+        }
+    }
+}
+
+/// Parse an "LMHASH:NTHASH" / ":NTHASH" / "NTHASH" string into the 16 byte NT
+/// hash. Shared by the sessions and gpo modules.
+pub fn nt_hash_from_str(raw: &str) -> Option<[u8; 16]> {
+    let nt = raw.trim().rsplit(':').next().unwrap_or(raw).trim();
+    if nt.len() != 32 || !nt.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let mut out = [0u8; 16];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&nt[i * 2..i * 2 + 2], 16).ok()?;
+    }
+    Some(out)
 }

--- a/src/transport/smb.rs
+++ b/src/transport/smb.rs
@@ -149,7 +149,7 @@ pub async fn open_rpc_pipe(
 pub async fn list_dir(smb: &mut SmbClient, host: &str, path: &str) -> anyhow::Result<Vec<DirEntry>> {
     let shown = if path.is_empty() { r"\" } else { path };
     trace!("[{host}] SMB list dir {shown}");
-    smb.list_dir(path).await.map_err(|e| {
+    smb.list_directory(path).await.map_err(|e| {
         warn!("[{host}] cannot list {shown}: {e}");
         anyhow::anyhow!("list {shown}: {e}")
     })


### PR DESCRIPTION
## Summary

Adds GPO-based collection for two BloodHound outputs that were previously empty:

- **GPOChanges** on OU and Domain objects (LocalAdmins / RemoteDesktopUsers / DcomUsers / PSRemoteUsers), issue #56
- **UserRights** on Computer objects (privilege assignments such as SeRemoteInteractiveLogonRight), issue #47

Both are derived by reading each GPO's template files off the DC SYSVOL share, with no per-machine RPC.

## Problem

RustHound-CE parsed `GptTmpl.inf` and `Groups.xml` but never retrieved them, and never mapped their directives onto the graph. As a result `GPOChanges` only ever carried `AffectedComputers` (set by the checker) and `UserRights` stayed empty. This misses the GPO-pushed local admin / RDP / DCOM / PSRemote memberships and the user-rights assignments that SharpHound collects. Thanks @devdudumuniz for all the work regarding GPO file parsing!

## Approach

- **Transport.** A share-agnostic SMB layer (`transport::smb`) authenticates once (password or pass-the-hash) and tree-connects the share it needs: IPC$ for the sessions module, SYSVOL for GPO files. Non-destructive `read_file` / `list_directory` come from a companion PR to `smb2-client`.
- **Collection.** `modules::gpo::sysvol` walks `\\dc\SYSVOL\<domain>\Policies\{GUID}\...`, reads `GptTmpl.inf` and `Groups.xml`, and feeds the existing parsers. Absent files are skipped quietly (most GPOs carry neither).
- **Mapping.** `modules::gpo::local_group` mirrors SharpHound's `GPOLocalGroupProcessor`: it builds add/remove actions from Restricted Groups and GPP, then merges per built-in group as `RestrictedMemberOf + (RestrictedMember if any else the LocalGroup result)`. Privileges are resolved per privilege and applied to the affected computers.
- **Reuse, no duplication.** The mapper reuses the checker's work instead of recomputing it: `AffectedComputers` is left as `add_affected_computers*` set it, and links are correlated by GPO SID (via `dn_sid`) because `replace_guid_gplink` already ran. Only the four local-group vectors and the computers' `UserRights` are filled.
- **Wiring.** Runs from `run_modules` when the collection method is `All` or `DCOnly` (SYSVOL is DC-side I/O). The module is invoked after LDAP collection and the checker, before JSON serialization.

## Scope

- New: `transport::smb` file helpers, `modules::gpo::sysvol`, `modules::gpo::local_group`, `CollectionMethod::does_gpo()`.
- Changed: `run_modules` now takes `&mut ADResults`; `ldapfqdn` is now `Option<String>` (sentinel removed); `LdapOnly` collection method wired up; a few read-only getters added on Domain/Group/Computer objects; `modules` moved into the library crate.
- Output format unchanged, this only populates existing `GPOChanges` / `UserRights` fields.