### PR TITLE
fix(gpo): honor computer configuration status

### DIFF
--- a/src/modules/gpo/sysvol.rs
+++ b/src/modules/gpo/sysvol.rs
@@ -9,8 +9,11 @@
 //! (GPO GUID -> links -> affected computers, name -> SID) belongs to a later
 //! layer, matching the module's existing split.
 
+use std::collections::HashSet;
+
 use log::{debug, info, warn};
 
+use crate::objects::gpo::Gpo;
 use crate::transport::smb::{connect_sysvol, list_dir, try_read_file, SmbAuth};
 
 use super::types::{GppLocalGroup, PrivilegeAssignment, RestrictedGroupDirective};
@@ -27,7 +30,10 @@ pub struct SysvolGpo {
 
 impl SysvolGpo {
     fn new(guid: String) -> Self {
-        SysvolGpo { guid, ..Default::default() }
+        SysvolGpo {
+            guid,
+            ..Default::default()
+        }
     }
     fn has_directives(&self) -> bool {
         !self.privileges.is_empty()
@@ -67,6 +73,7 @@ pub async fn collect(
     domain: &str,
     user: &str,
     auth: SmbAuth<'_>,
+    scope: &ComputerGpoScope,
 ) -> anyhow::Result<Vec<SysvolGpo>> {
     let mut smb = connect_sysvol(dc_host, domain, user, auth).await?;
 
@@ -76,6 +83,13 @@ pub async fn collect(
     let mut out = Vec::new();
     for entry in entries {
         if !entry.is_dir || !is_gpo_guid(&entry.name) {
+            continue;
+        }
+        if !scope.allows(&entry.name) {
+            debug!(
+                "[gpo] skipping computer-disabled GPO {} before SYSVOL reads",
+                entry.name
+            );
             continue;
         }
         let files = gpo_file_paths(&policies_root, &entry.name);
@@ -90,8 +104,8 @@ pub async fn collect(
                 }
                 Err(err) => warn!("[gpo] {} GptTmpl.inf parse: {err}", gpo.guid),
             },
-            Ok(None) => {}          // absent, normal
-            Err(_) => {}            // real error already logged by try_read_file
+            Ok(None) => {} // absent, normal
+            Err(_) => {}   // real error already logged by try_read_file
         }
 
         // GPP Groups.xml: local group membership (#56), machine and user scope.
@@ -118,17 +132,104 @@ pub async fn collect(
         }
     }
 
-    info!("[gpo] collected directives from {} GPO(s) on {dc_host} SYSVOL", out.len());
+    info!(
+        "[gpo] collected directives from {} GPO(s) on {dc_host} SYSVOL",
+        out.len()
+    );
     Ok(out)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+
+    use ldap3::SearchEntry;
+
+    use crate::modules::gpo::local_group::{
+        compute_merged, resolve_privileges, Resolver, TypedPrincipal,
+    };
+    use crate::modules::gpo::{parse_gpttmpl, parse_groups_xml};
+    use crate::objects::gpo::Gpo;
+
+    struct FakeResolver;
+
+    impl Resolver for FakeResolver {
+        fn resolve_name(&self, _name: &str) -> Option<(String, String)> {
+            None
+        }
+
+        fn type_of_sid(&self, _sid: &str) -> Option<String> {
+            Some("User".to_string())
+        }
+    }
+
+    fn parsed_gpo(guid: &str, flags: &str) -> Gpo {
+        let result = SearchEntry {
+            dn: format!("CN={guid},CN=Policies,CN=System,DC=example,DC=local"),
+            attrs: HashMap::from([
+                ("displayName".to_string(), vec![format!("GPO {flags}")]),
+                (
+                    "gPCFileSysPath".to_string(),
+                    vec![format!(
+                        r"\\example.local\SYSVOL\example.local\Policies\{guid}"
+                    )],
+                ),
+                ("flags".to_string(), vec![flags.to_string()]),
+            ]),
+            bin_attrs: HashMap::new(),
+        };
+        let mut gpo = Gpo::new();
+        gpo.parse(
+            result,
+            "example.local",
+            &mut HashMap::new(),
+            &mut HashMap::new(),
+            "S-1-5-21-111111111-222222222-333333333",
+            &HashMap::new(),
+        )
+        .unwrap();
+        gpo
+    }
+
+    fn sysvol_policy(guid: &str, principal_rid: u32) -> SysvolGpo {
+        let principal = format!("S-1-5-21-111111111-222222222-333333333-{principal_rid}");
+        let inf = format!(
+            "[Privilege Rights]\nSeRemoteInteractiveLogonRight = *{principal}\n\
+             [Group Membership]\n*S-1-5-32-544__Members = *{principal}\n"
+        );
+        let parsed_inf = parse_gpttmpl(&inf).unwrap();
+        let xml = format!(
+            r#"<Groups>
+<Group><Properties action="U" groupSid="S-1-5-32-555"><Members><Member sid="{principal}" action="ADD"/></Members></Properties></Group>
+<Group><Properties action="U" groupSid="S-1-5-32-562"><Members><Member sid="{principal}" action="ADD"/></Members></Properties></Group>
+<Group><Properties action="U" groupSid="S-1-5-32-580"><Members><Member sid="{principal}" action="ADD"/></Members></Properties></Group>
+</Groups>"#
+        );
+
+        SysvolGpo {
+            guid: guid.to_string(),
+            privileges: parsed_inf.privilege_rights().to_vec(),
+            restricted_groups: parsed_inf.restricted_groups().to_vec(),
+            gpp_local_groups: parse_groups_xml(xml.as_bytes()).unwrap(),
+        }
+    }
+
+    fn assert_no_sid_suffix(principals: &[TypedPrincipal], suffix: &str) {
+        assert!(
+            principals
+                .iter()
+                .all(|principal| !principal.sid.ends_with(suffix)),
+            "found computer-disabled principal ending in {suffix}: {principals:?}",
+        );
+    }
 
     #[test]
     fn gpo_file_paths_are_canonical() {
-        let f = gpo_file_paths(r"DOMAIN.LOCAL\Policies", "{31B2F340-016D-11D2-945F-00C04FB984F9}");
+        let f = gpo_file_paths(
+            r"DOMAIN.LOCAL\Policies",
+            "{31B2F340-016D-11D2-945F-00C04FB984F9}",
+        );
         assert_eq!(
             f.gpttmpl,
             r"DOMAIN.LOCAL\Policies\{31B2F340-016D-11D2-945F-00C04FB984F9}\Machine\Microsoft\Windows NT\SecEdit\GptTmpl.inf"
@@ -137,7 +238,9 @@ mod tests {
             f.groups_machine,
             r"DOMAIN.LOCAL\Policies\{31B2F340-016D-11D2-945F-00C04FB984F9}\Machine\Preferences\Groups\Groups.xml"
         );
-        assert!(f.groups_user.ends_with(r"\User\Preferences\Groups\Groups.xml"));
+        assert!(f
+            .groups_user
+            .ends_with(r"\User\Preferences\Groups\Groups.xml"));
     }
 
     #[test]
@@ -154,7 +257,106 @@ mod tests {
     fn has_directives_reflects_content() {
         let mut g = SysvolGpo::new("{G}".into());
         assert!(!g.has_directives());
-        g.privileges.push(PrivilegeAssignment::new("SeDebugPrivilege", vec!["DOMAIN\\alice".into()]));
+        g.privileges.push(PrivilegeAssignment::new(
+            "SeDebugPrivilege",
+            vec!["DOMAIN\\alice".into()],
+        ));
         assert!(g.has_directives());
+    }
+
+    #[test]
+    fn computer_scope_allows_flags_zero_and_one_only() {
+        let guids = [
+            "{AbCdEfAb-CdEf-AbCd-EfAb-CdEfAbCdEfAb}",
+            "{11111111-1111-1111-1111-111111111111}",
+            "{22222222-2222-2222-2222-222222222222}",
+            "{33333333-3333-3333-3333-333333333333}",
+        ];
+        let gpos: Vec<Gpo> = guids
+            .iter()
+            .zip(["0", "1", "2", "3"])
+            .map(|(guid, flags)| parsed_gpo(guid, flags))
+            .collect();
+
+        let scope = ComputerGpoScope::from_gpos(&gpos);
+
+        assert!(scope.allows(guids[0]));
+        assert!(scope.allows(&guids[0].to_ascii_uppercase()));
+        assert!(scope.allows(&guids[0].to_ascii_lowercase()));
+        assert!(scope.allows(guids[1]));
+        assert!(!scope.allows(guids[2]));
+        assert!(!scope.allows(guids[3]));
+    }
+
+    #[test]
+    fn flags_two_and_three_leave_no_local_group_or_user_right_output() {
+        let guids = [
+            "{00000000-0000-0000-0000-000000000000}",
+            "{11111111-1111-1111-1111-111111111111}",
+            "{22222222-2222-2222-2222-222222222222}",
+            "{33333333-3333-3333-3333-333333333333}",
+        ];
+        let metadata: Vec<Gpo> = guids
+            .iter()
+            .zip(["0", "1", "2", "3"])
+            .map(|(guid, flags)| parsed_gpo(guid, flags))
+            .collect();
+        let sysvol: Vec<SysvolGpo> = guids
+            .iter()
+            .enumerate()
+            .map(|(flags, guid)| sysvol_policy(guid, 1000 + flags as u32))
+            .collect();
+        let scope = ComputerGpoScope::from_gpos(&metadata);
+        let applicable = scope.applicable(&sysvol);
+
+        assert_eq!(
+            applicable
+                .iter()
+                .map(|gpo| gpo.guid.as_str())
+                .collect::<Vec<_>>(),
+            vec![guids[0], guids[1]],
+        );
+
+        let merged = compute_merged(&applicable, &FakeResolver);
+        for principals in [
+            &merged.local_admins,
+            &merged.remote_desktop_users,
+            &merged.dcom_users,
+            &merged.psremote_users,
+        ] {
+            assert_no_sid_suffix(principals, "1002");
+            assert_no_sid_suffix(principals, "1003");
+        }
+
+        let privileges = resolve_privileges(&applicable, &FakeResolver);
+        assert_eq!(privileges.len(), 1);
+        assert_no_sid_suffix(&privileges[0].1, "1002");
+        assert_no_sid_suffix(&privileges[0].1, "1003");
+    }
+}
+
+/// GPO folders whose computer configuration is applicable according to LDAP.
+#[derive(Debug, Default)]
+pub struct ComputerGpoScope {
+    guids: HashSet<String>,
+}
+
+impl ComputerGpoScope {
+    pub fn from_gpos(gpos: &[Gpo]) -> Self {
+        let guids = gpos
+            .iter()
+            .filter(|gpo| gpo.computer_configuration_enabled())
+            .filter_map(Gpo::sysvol_guid)
+            .collect();
+        Self { guids }
+    }
+
+    pub(crate) fn allows(&self, guid: &str) -> bool {
+        self.guids.contains(&guid.to_uppercase())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn applicable<'a>(&self, gpos: &'a [SysvolGpo]) -> Vec<&'a SysvolGpo> {
+        gpos.iter().filter(|gpo| self.allows(&gpo.guid)).collect()
     }
 }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,8 +1,8 @@
 //! List of RustHound add-on modules
+pub mod adcs;
 pub mod gpo;
 pub mod resolver;
 pub mod sessions;
-pub mod adcs;
 
 use std::error::Error;
 
@@ -13,75 +13,82 @@ use crate::args::{CollectionMethod, Options};
 use crate::modules::adcs::probe_enterpriseca_esc8;
 
 /// Function to run all modules requested
-pub async fn run_modules(
-    common_args: &Options,
-    ad: &mut ADResults,
-) -> Result<(), Box<dyn Error>> {
-
-   // [MODULE - RESOLVER] Resolve FQDN to IP address.
-   if common_args.fqdn_resolver {
+pub async fn run_modules(common_args: &Options, ad: &mut ADResults) -> Result<(), Box<dyn Error>> {
+    // [MODULE - RESOLVER] Resolve FQDN to IP address.
+    if common_args.fqdn_resolver {
         resolver::resolv::resolving_all_fqdn(
             common_args.dns_tcp,
             &common_args.name_server,
             &mut ad.mappings.fqdn_ip,
             &ad.computers,
-        ).await;
-   }
+        )
+        .await;
+    }
 
-   // [MODULE - SESSIONS] Just does user session collection 
-   // <https://github.com/g0h4n/HasSession-rs>
-   //
-   // - SRVSVC / NetrSessionEnum - inbound SMB sessions (client IP + username).
-   // - WKSSVC / NetrWkstaUserEnum - users with an active logon context on the machine.
-   // - WINREG / HKEY_USERS - SIDs of loaded profile hives (= logged-on users).
-   if common_args.collection_method.does_sessions() {
+    // [MODULE - SESSIONS] Just does user session collection
+    // <https://github.com/g0h4n/HasSession-rs>
+    //
+    // - SRVSVC / NetrSessionEnum - inbound SMB sessions (client IP + username).
+    // - WKSSVC / NetrWkstaUserEnum - users with an active logon context on the machine.
+    // - WINREG / HKEY_USERS - SIDs of loaded profile hives (= logged-on users).
+    if common_args.collection_method.does_sessions() {
         sessions::run(common_args, &ad.users, &mut ad.computers).await?;
-   }
+    }
 
-   // [MODULE - ESC8] Web enrollment probe on all enterprise CAs.
-   // Skipped in DCOnly mode (no direct machine connections allowed).
-   // Uses rayon to probe all CAs in parallel (each probe has a 5 s timeout).
-   if !matches!(common_args.collection_method, CollectionMethod::DCOnly) 
-      && !matches!(common_args.collection_method, CollectionMethod::LdapOnly) 
-      && !ad.enterprisecas.is_empty() 
-   {
-      log::info!("Starting ESC8 web enrollment probe on {} CA(s)...", ad.enterprisecas.len());
-      ad.enterprisecas.par_iter_mut().for_each(|ca| {
-         let esc8 = probe_enterpriseca_esc8(ca.dns_host());
-         ca.apply_esc8(esc8.http_enrollment_endpoints);
-      });
-   }
+    // [MODULE - ESC8] Web enrollment probe on all enterprise CAs.
+    // Skipped in DCOnly mode (no direct machine connections allowed).
+    // Uses rayon to probe all CAs in parallel (each probe has a 5 s timeout).
+    if !matches!(common_args.collection_method, CollectionMethod::DCOnly)
+        && !matches!(common_args.collection_method, CollectionMethod::LdapOnly)
+        && !ad.enterprisecas.is_empty()
+    {
+        log::info!(
+            "Starting ESC8 web enrollment probe on {} CA(s)...",
+            ad.enterprisecas.len()
+        );
+        ad.enterprisecas.par_iter_mut().for_each(|ca| {
+            let esc8 = probe_enterpriseca_esc8(ca.dns_host());
+            ca.apply_esc8(esc8.http_enrollment_endpoints);
+        });
+    }
 
     // [MODULE - GPO SYSVOL] read GptTmpl.inf / Groups.xml off the DC SYSVOL share.
     // <#47 Privileges> and <#56 LocalGroup>. DC-side I/O, so it also runs in DCOnly.
     if common_args.collection_method.does_gpo() {
-      let sysvol = match collect_sysvol_targets(common_args).await {
-         Ok(v) => v,
-         Err(e) => {
-            log::warn!("[gpo] SYSVOL collection failed: {e}");
-            Vec::new()
-         }
-      };
-      if !sysvol.is_empty() {
-         log::info!("[gpo] mapping {} GPO(s) to GPOChanges / UserRights", sysvol.len());
-         gpo::apply_gpo(
-            &mut ad.ous,
-            &mut ad.domains,
-            &ad.users,
-            &ad.groups,
-            &mut ad.computers,
-            &sysvol,
-            &ad.mappings.dn_sid,
-         );
-      }
-   }
+        let computer_scope = gpo::sysvol::ComputerGpoScope::from_gpos(&ad.gpos);
+        let sysvol = match collect_sysvol_targets(common_args, &computer_scope).await {
+            Ok(v) => v,
+            Err(e) => {
+                log::warn!("[gpo] SYSVOL collection failed: {e}");
+                Vec::new()
+            }
+        };
+        if !sysvol.is_empty() {
+            log::info!(
+                "[gpo] mapping {} GPO(s) to GPOChanges / UserRights",
+                sysvol.len()
+            );
+            gpo::apply_gpo(
+                &mut ad.ous,
+                &mut ad.domains,
+                &ad.users,
+                &ad.groups,
+                &mut ad.computers,
+                &sysvol,
+                &ad.mappings.dn_sid,
+            );
+        }
+    }
 
-   // Other modules need to be add here...
-   Ok(())
+    // Other modules need to be add here...
+    Ok(())
 }
 
 /// Build the SMB target and credentials, then collect GPO directives off SYSVOL.
-async fn collect_sysvol_targets(common_args: &Options) -> anyhow::Result<Vec<gpo::SysvolGpo>> {
+async fn collect_sysvol_targets(
+    common_args: &Options,
+    computer_scope: &gpo::sysvol::ComputerGpoScope,
+) -> anyhow::Result<Vec<gpo::SysvolGpo>> {
     use crate::transport::smb::{nt_hash_from_str, SmbAuth};
 
     let user = common_args.username.clone().unwrap_or_default();
@@ -93,19 +100,29 @@ async fn collect_sysvol_targets(common_args: &Options) -> anyhow::Result<Vec<gpo
     };
 
     // SMB target: explicit IP first, then the DC FQDN, then the domain value.
-   let dc_host = common_args
-      .ip
-      .as_deref()
-      .filter(|s| !s.is_empty())
-      .or(common_args.ldapfqdn.as_deref())
-      .map(str::to_string)
-      .unwrap_or_else(|| common_args.domain.clone());
+    let dc_host = common_args
+        .ip
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .or(common_args.ldapfqdn.as_deref())
+        .map(str::to_string)
+        .unwrap_or_else(|| common_args.domain.clone());
 
     if dc_host.is_empty() {
-        log::warn!("[gpo] no SMB target (ip/ldapfqdn/domain) available, skipping SYSVOL collection");
+        log::warn!(
+            "[gpo] no SMB target (ip/ldapfqdn/domain) available, skipping SYSVOL collection"
+        );
         return Ok(Vec::new());
     }
 
     // domain_fqdn (SYSVOL sub-root) = the domain DNS name.
-    gpo::collect_sysvol(&dc_host, &common_args.domain, &common_args.domain, &user, auth).await
+    gpo::collect_sysvol(
+        &dc_host,
+        &common_args.domain,
+        &common_args.domain,
+        &user,
+        auth,
+        computer_scope,
+    )
+    .await
 }

--- a/src/objects/gpo.rs
+++ b/src/objects/gpo.rs
@@ -1,13 +1,13 @@
-use serde_json::value::Value;
-use serde::{Deserialize, Serialize};
 use ldap3::SearchEntry;
-use log::{debug, trace};
+use log::{debug, trace, warn};
+use serde::{Deserialize, Serialize};
+use serde_json::value::Value;
 use std::collections::HashMap;
 use std::error::Error;
 
-use crate::objects::common::{LdapObject, AceTemplate, Link, SPNTarget, Member};
-use crate::enums::decode_guid_le;
 use crate::enums::acl::parse_ntsecuritydescriptor;
+use crate::enums::decode_guid_le;
+use crate::objects::common::{AceTemplate, LdapObject, Link, Member, SPNTarget};
 use crate::utils::date::string_to_epoch;
 
 /// Gpo structure
@@ -31,10 +31,42 @@ pub struct Gpo {
 
 impl Gpo {
     // New gpo.
-    pub fn new() -> Self { 
-        Self { ..Default::default() } 
+    pub fn new() -> Self {
+        Self {
+            ..Default::default()
+        }
     }
-    
+
+    /// Whether the GPO's computer configuration is applicable.
+    pub fn computer_configuration_enabled(&self) -> bool {
+        if self.properties.gpostatus.is_empty() {
+            warn!(
+                "GPO {} has no flags value; treating computer configuration as enabled for SharpHound compatibility",
+                self.properties.distinguishedname
+            );
+            return true;
+        }
+
+        match self.properties.gpostatus.parse::<u32>() {
+            Ok(flags) => flags & 0x2 == 0,
+            Err(_) => {
+                warn!(
+                    "GPO {} has invalid flags value {:?}; skipping computer configuration",
+                    self.properties.distinguishedname, self.properties.gpostatus
+                );
+                false
+            }
+        }
+    }
+
+    pub(crate) fn sysvol_guid(&self) -> Option<String> {
+        self.properties
+            .gpcpath
+            .rsplit(['\\', '/'])
+            .find(|part| !part.is_empty())
+            .map(str::to_uppercase)
+    }
+
     /// Function to parse and replace value for GPO object.
     /// <https://bloodhound.readthedocs.io/en/latest/further-reading/json.html#gpos>
     pub fn parse(
@@ -87,6 +119,9 @@ impl Gpo {
                 "gPCFileSysPath" => {
                     self.properties.gpcpath = value[0].to_owned();
                 }
+                "flags" => {
+                    self.properties.gpostatus = value.first().cloned().unwrap_or_default();
+                }
                 "isDeleted" => {
                     self.is_deleted = true;
                 }
@@ -124,10 +159,7 @@ impl Gpo {
             self.object_identifier.to_string(),
         );
         // Push DN and Type
-        sid_type.insert(
-            self.object_identifier.to_string(),
-            "Gpo".to_string(),
-        );
+        sid_type.insert(self.object_identifier.to_string(), "Gpo".to_string());
 
         // Trace and return Gpo struct
         // trace!("JSON OUTPUT: {:?}",serde_json::to_string(&self).unwrap());
@@ -169,7 +201,7 @@ impl LdapObject for Gpo {
     fn get_haslaps(&self) -> &bool {
         &false
     }
-    
+
     // Get mutable values
     fn get_aces_mut(&mut self) -> &mut Vec<AceTemplate> {
         &mut self.aces
@@ -180,7 +212,7 @@ impl LdapObject for Gpo {
     fn get_allowed_to_delegate_mut(&mut self) -> &mut Vec<Member> {
         panic!("Not used by current object.");
     }
-    
+
     // Edit values
     fn set_is_acl_protected(&mut self, is_acl_protected: bool) {
         self.is_acl_protected = is_acl_protected;
@@ -209,13 +241,89 @@ impl LdapObject for Gpo {
 // Gpo properties structure
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct GpoProperties {
-   domain: String,
-   name: String,
-   distinguishedname: String,
-   domainsid: String,
-   isaclprotected: bool,
-   highvalue: bool,
-   description: Option<String>,
-   whencreated: i64,
-   gpcpath: String
+    domain: String,
+    name: String,
+    distinguishedname: String,
+    domainsid: String,
+    isaclprotected: bool,
+    highvalue: bool,
+    description: Option<String>,
+    whencreated: i64,
+    gpcpath: String,
+    gpostatus: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_gpo_with_flags(flags: Option<&str>) -> Gpo {
+        let mut attrs = HashMap::from([
+            ("displayName".to_string(), vec!["Test GPO".to_string()]),
+            (
+                "gPCFileSysPath".to_string(),
+                vec![r"\\example.local\SYSVOL\example.local\Policies\{00000000-0000-0000-0000-000000000000}".to_string()],
+            ),
+        ]);
+        if let Some(flags) = flags {
+            attrs.insert("flags".to_string(), vec![flags.to_string()]);
+        }
+        let result = SearchEntry {
+            dn: "CN={00000000-0000-0000-0000-000000000000},CN=Policies,CN=System,DC=example,DC=local".to_string(),
+            attrs,
+            bin_attrs: HashMap::new(),
+        };
+        let mut gpo = Gpo::new();
+        let mut dn_sid = HashMap::new();
+        let mut sid_type = HashMap::new();
+
+        gpo.parse(
+            result,
+            "example.local",
+            &mut dn_sid,
+            &mut sid_type,
+            "S-1-5-21-111111111-222222222-333333333",
+            &HashMap::new(),
+        )
+        .unwrap();
+
+        gpo
+    }
+
+    #[test]
+    fn parse_preserves_gpo_status_for_all_defined_flag_values() {
+        for flags in ["0", "1", "2", "3"] {
+            let gpo = parse_gpo_with_flags(Some(flags));
+            assert_eq!(
+                gpo.to_json()["Properties"]["gpostatus"],
+                flags,
+                "flags={flags} should be retained as gpostatus",
+            );
+        }
+    }
+
+    #[test]
+    fn computer_configuration_applicability_follows_flags_bit_one() {
+        let cases = [
+            (Some("0"), true),
+            (Some("1"), true),
+            (Some("2"), false),
+            (Some("3"), false),
+            (Some("4"), true),
+            (Some("6"), false),
+            (None, true),
+            (Some(""), true),
+            (Some("not-a-number"), false),
+            (Some("4294967296"), false),
+        ];
+
+        for (flags, expected) in cases {
+            let gpo = parse_gpo_with_flags(flags);
+            assert_eq!(
+                gpo.computer_configuration_enabled(),
+                expected,
+                "unexpected computer applicability for flags={flags:?}",
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Problem

Computer-disabled GPOs can currently contribute machine-side local-group and user-right data. A GPO with `flags=2` or `flags=3` is still enumerated from SYSVOL and mapped into BloodHound output.

## Root cause

The LDAP query already requests all ordinary attributes, but `Gpo::parse` discards `groupPolicyContainer.flags`. Because the model has no status, the SYSVOL collector has no applicability gate before reading `GptTmpl.inf` and `Groups.xml`.

## Fix

- retain the LDAP value as `Properties.gpostatus`, matching the current SharpHound output contract;
- expose the computer-configuration applicability rule on `Gpo`;
- derive eligible SYSVOL GUIDs from collected LDAP GPO metadata;
- skip computer-disabled GPO folders before constructing or reading their policy file paths.

Missing/empty flags retain SharpHound-compatible behavior with an explicit warning. Nonnumeric and above-`u32` values warn and fail closed. Unknown in-range bits are ignored as required by MS-GPOL.

## Protocol behavior

- `flags=0`: process computer policy
- `flags=1`: process computer policy; only user configuration is disabled
- `flags=2`: skip computer policy
- `flags=3`: skip computer policy

References:
- [MS-GPOD: Completing the GPO Configuration](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpod/d360d288-d7d5-49a9-83be-603805da1379)
- [MS-GPOL: GPO Search](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpol/b0e5c9e8-e858-4a7a-a94a-4a3d0a9d87a2)

## Regression tests

The synthetic matrix covers flags 0/1/2/3 for:

- Restricted Groups;
- GPP `Groups.xml`;
- Privilege Rights.

It verifies that flags 2/3 leave no `LocalAdmins`, `RemoteDesktopUsers`, `DcomUsers`, `PSRemoteUsers`, or `UserRights` output, while flags 1 remains active for computer policy.

## Validation

- `rustfmt --check` on the three changed Rust files: PASS
- GUID case normalization (uppercase/lowercase/mixed): PASS
- `cargo test --all-targets`: PASS (105 tests)
- `cargo clippy --all-targets -- -A warnings`: PASS
- `cargo clippy --all-targets`: PASS; existing upstream warnings remain, with no new warning in the changed GPO code
- `cargo build`: PASS
- `cargo build --release`: PASS
- Rust 1.85.0 `cargo test --all-targets`: PASS (105 tests)
- `git diff upstream/main...HEAD --check`: PASS
- focused security diff review: PASS, no reportable findings

`FMT_GLOBAL=BASELINE_FAIL_ACCEPTED`: current `upstream/main` fails `cargo fmt --check` in 59 files. The branch leaves the remaining 56 baseline files untouched.

`FMT_CHANGED_FILES=PASS`

## Non-goals

This PR does not change GPLink option handling, `gPCFunctionalityVersion`, WMI/security filtering, SMB transport, parser semantics, session collection, ADCS, or unrelated CLI behavior.

Regression follow-up to #60 / #56.
Fixes #62.

