### PR TITLE
feat: Kerberos (pass-the-ticket) authentication for the SMB transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ datas/
 rusthound-ce*
 .vscode
 .rusthound-cache
+*.ccache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,6 +1803,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ms-pac-forge"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a413d7f67644e2f3a18d333b5b43632ff2ca48b6c14ccd4f287a15723484d546"
+dependencies = [
+ "anyhow",
+ "hex",
+ "hmac",
+ "md-5",
+ "md4",
+ "picky-asn1",
+ "picky-asn1-der",
+ "picky-krb 0.9.6",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,6 +2144,31 @@ dependencies = [
  "serde",
  "widestring",
  "zeroize",
+]
+
+[[package]]
+name = "picky-krb"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd326177336b27707c6f969e14f57a54d6b521ce95cce55785ce02525052783"
+dependencies = [
+ "aes",
+ "byteorder",
+ "cbc",
+ "crypto",
+ "des",
+ "hmac",
+ "num-bigint-dig",
+ "oid",
+ "pbkdf2",
+ "picky-asn1",
+ "picky-asn1-der",
+ "picky-asn1-x509",
+ "rand 0.8.5",
+ "serde",
+ "sha1",
+ "thiserror 1.0.69",
+ "uuid",
 ]
 
 [[package]]
@@ -2626,12 +2668,16 @@ dependencies = [
  "ldap3",
  "log",
  "mimalloc",
+ "ms-pac-forge",
  "nom",
  "obfstr",
  "once_cell",
  "picky",
- "picky-krb",
+ "picky-asn1",
+ "picky-asn1-der",
+ "picky-krb 0.11.1",
  "quick-xml",
+ "rand 0.8.5",
  "rayon",
  "regex",
  "reqwest",
@@ -2991,7 +3037,7 @@ dependencies = [
  "picky-asn1",
  "picky-asn1-der",
  "picky-asn1-x509",
- "picky-krb",
+ "picky-krb 0.11.1",
  "rand 0.8.5",
  "rsa",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,11 @@ smb2-client = "0.2.4"
 dcerpc      = "0.2.7"
 # es8 check
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
-
+# Kerberos SMB auth
+picky-asn1      = "0.10"
+picky-asn1-der  = "0.5"
+ms-pac-forge    = "0.1.3"
+rand = "0.8"
 
 [features]
 noargs = ["winreg"] # Only available for Windows

--- a/src/modules/gpo/mod.rs
+++ b/src/modules/gpo/mod.rs
@@ -17,5 +17,4 @@ pub use types::{
     GpoError, GppGroupAction, GppGroupMember, GppLocalGroup, GppMemberAction, GptTmplPolicy,
     PrivilegeAssignment, RestrictedGroupDirective, RestrictedGroupOperation,
 };
-pub use sysvol::{collect as collect_sysvol, SysvolGpo};
 pub use local_group::{apply_gpo, compute_merged, resolve_privileges, ObjectResolver, Resolver};

--- a/src/modules/gpo/sysvol.rs
+++ b/src/modules/gpo/sysvol.rs
@@ -15,6 +15,7 @@ use log::{debug, info, warn};
 
 use crate::objects::gpo::Gpo;
 use crate::transport::smb::{connect_sysvol, list_dir, try_read_file, SmbAuth};
+use crate::args::Options;
 
 use super::types::{GppLocalGroup, PrivilegeAssignment, RestrictedGroupDirective};
 use super::{parse_gpttmpl_bytes, parse_groups_xml};
@@ -63,11 +64,51 @@ fn is_gpo_guid(name: &str) -> bool {
     name.len() >= 3 && name.starts_with('{') && name.ends_with('}')
 }
 
+/// Build the SMB target and credentials, then collect GPO directives off SYSVOL.
+pub async fn collect_sysvol_targets(common_args: &Options, scope: &ComputerGpoScope) -> anyhow::Result<Vec<SysvolGpo>> {
+    use crate::transport::smb::{nt_hash_from_str, SmbAuth};
+
+    let user = common_args.username.clone().unwrap_or_default();
+    let password = common_args.password.clone().unwrap_or_default();
+    let nt = common_args.hashes.as_deref().and_then(nt_hash_from_str);
+
+    // SMB target (the DC): ldapfqdn, else IP, else domain.
+    let dc_host: String = common_args
+        .ldapfqdn
+        .clone()
+        .filter(|s| !s.is_empty())
+        .or_else(|| common_args.ip.clone())
+        .unwrap_or_else(|| common_args.domain.clone());
+
+    if dc_host.is_empty() {
+        log::warn!("[gpo] no SMB target (ldapfqdn/ip/domain), skipping SYSVOL collection");
+        return Ok(Vec::new());
+    }
+
+    // Kerberos: build a cifs/<dc> ticket from KRB5CCNAME when --kerberos is set.
+    if common_args.kerberos {
+        let ccache = std::env::var("KRB5CCNAME")
+            .map_err(|_| anyhow::anyhow!("--kerberos set but KRB5CCNAME is not defined"))?;
+        let spn = format!("cifs/{dc_host}");
+        let (gss_blob, session_key) =
+            crate::transport::kerberos::kerberos_material_for(&ccache, &spn, &dc_host).await?;
+        let auth = SmbAuth::Kerberos { gss_blob: &gss_blob, session_key: &session_key };
+        return collect(&dc_host, &common_args.domain, &common_args.domain, &user, auth, scope).await;
+    }
+
+    // Password / pass the hash.
+    let auth = match &nt {
+        Some(h) => SmbAuth::Hash(h),
+        None => SmbAuth::Password(&password),
+    };
+    collect(&dc_host, &common_args.domain, &common_args.domain, &user, auth, scope).await
+}
+
 /// Connect to `dc_host` SYSVOL and collect GPO directives.
 ///
 /// `domain_fqdn` is the SYSVOL sub-root (e.g. "DOMAIN.LOCAL"), `domain`/`user`
 /// and `auth` are the SMB credentials.
-pub async fn collect(
+async fn collect(
     dc_host: &str,
     domain_fqdn: &str,
     domain: &str,

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -11,6 +11,7 @@ use rayon::prelude::*;
 use crate::api::ADResults;
 use crate::args::{CollectionMethod, Options};
 use crate::modules::adcs::probe_enterpriseca_esc8;
+use crate::modules::gpo::sysvol::collect_sysvol_targets;
 
 /// Function to run all modules requested
 pub async fn run_modules(common_args: &Options, ad: &mut ADResults) -> Result<(), Box<dyn Error>> {
@@ -82,47 +83,4 @@ pub async fn run_modules(common_args: &Options, ad: &mut ADResults) -> Result<()
 
     // Other modules need to be add here...
     Ok(())
-}
-
-/// Build the SMB target and credentials, then collect GPO directives off SYSVOL.
-async fn collect_sysvol_targets(
-    common_args: &Options,
-    computer_scope: &gpo::sysvol::ComputerGpoScope,
-) -> anyhow::Result<Vec<gpo::SysvolGpo>> {
-    use crate::transport::smb::{nt_hash_from_str, SmbAuth};
-
-    let user = common_args.username.clone().unwrap_or_default();
-    let password = common_args.password.clone().unwrap_or_default();
-    let nt = common_args.hashes.as_deref().and_then(nt_hash_from_str);
-    let auth = match &nt {
-        Some(h) => SmbAuth::Hash(h),
-        None => SmbAuth::Password(&password),
-    };
-
-    // SMB target: explicit IP first, then the DC FQDN, then the domain value.
-    let dc_host = common_args
-        .ip
-        .as_deref()
-        .filter(|s| !s.is_empty())
-        .or(common_args.ldapfqdn.as_deref())
-        .map(str::to_string)
-        .unwrap_or_else(|| common_args.domain.clone());
-
-    if dc_host.is_empty() {
-        log::warn!(
-            "[gpo] no SMB target (ip/ldapfqdn/domain) available, skipping SYSVOL collection"
-        );
-        return Ok(Vec::new());
-    }
-
-    // domain_fqdn (SYSVOL sub-root) = the domain DNS name.
-    gpo::collect_sysvol(
-        &dc_host,
-        &common_args.domain,
-        &common_args.domain,
-        &user,
-        auth,
-        computer_scope,
-    )
-    .await
 }

--- a/src/modules/sessions/mod.rs
+++ b/src/modules/sessions/mod.rs
@@ -19,14 +19,12 @@
 //!   * bounded concurrency (throttle) instead of a serial loop;
 //!   * names resolved to SIDs using the already-collected LDAP data.
 //!
+//! Authentication reuses the SMB transport: password, pass the hash, or a
+//! Kerberos ticket (pass the ticket) when --kerberos is set. Kerberos material
+//! is built per host, since the AP-REQ targets that host's cifs/<host> SPN.
+//!
 //! The target host is the computer FQDN (properties.name, from dNSHostName).
 //! We do NOT use the fqdn->ip map: connections go to the FQDN and rely on DNS.
-//!
-//! Accessors this module needs (add them to RustHound-CE if missing):
-//!   impl Computer          -> sessions_mut(), privileged_sessions_mut(),
-//!                             registry_sessions_mut() : &mut Session
-//!   impl ComputerProperties-> pwdlastset(&self) -> i64
-//!   impl User              -> object_identifier(&self) -> &String
 
 use std::collections::HashMap;
 use std::error::Error;
@@ -102,15 +100,33 @@ pub async fn run(
     let nt_hash = parse_hash(args.hashes.as_deref()); // "LM:NT" | ":NT" | "NT" -> [u8;16]
     let method = args.collection_method.clone();
 
+    // Kerberos: ccache path from KRB5CCNAME when --kerberos is set (computed once).
+    let kerberos_ccache: Option<String> = if args.kerberos {
+        std::env::var("KRB5CCNAME").ok()
+    } else {
+        None
+    };
+    // KDC (the DC) to request cifs/<host> service tickets from: FQDN, else IP, else domain.
+    let kdc: String = args
+        .ldapfqdn
+        .clone()
+        .filter(|s| !s.is_empty())
+        .or_else(|| args.ip.clone())
+        .unwrap_or_else(|| args.domain.clone());
+
     let findings: Vec<HostFindings> = stream::iter(targets)
         .map(|(host, computer_sid)| {
             let (sem, domain, user, password, method) =
                 (sem.clone(), domain.clone(), user.clone(), password.clone(), method.clone());
             let nt_hash = nt_hash;
+            let kerberos_ccache = kerberos_ccache.clone();
+            let kdc = kdc.clone();
             async move {
                 let _permit = sem.acquire().await.unwrap();
-                enumerate_host(&host, computer_sid, &domain, &user, &password,
-                               nt_hash.as_ref(), &method).await
+                enumerate_host(
+                    &host, computer_sid, &domain, &user, &password,
+                    nt_hash.as_ref(), kerberos_ccache.as_deref(), &kdc, &method,
+                ).await
             }
         })
         .buffer_unordered(DEFAULT_CONCURRENCY)
@@ -130,10 +146,13 @@ pub async fn run(
 }
 
 // Per-host enumeration (adapted from HasSession-rs enumerate_host)
+#[allow(clippy::too_many_arguments)]
 async fn enumerate_host(
     host: &str, computer_sid: String,
     domain: &str, user: &str, password: &str,
     nt_hash: Option<&[u8; 16]>,
+    kerberos_ccache: Option<&str>,
+    kdc: &str,
     method: &CollectionMethod,
 ) -> HostFindings {
     // SharpHound-style reachability pre-check: 445 open within budget
@@ -157,14 +176,23 @@ async fn enumerate_host(
         // Inner block uses `?` for the fatal connect/auth/tree steps; the error
         // is folded into `errors` instead of bubbling out of `work`.
         let fatal: Result<(), String> = async {
-
-            // Using transport/smb.rs 
-            let auth = match nt_hash {
-                Some(h) => SmbAuth::Hash(h),
-                None    => SmbAuth::Password(password),
+            // connect + SESSION_SETUP: Kerberos ticket, or password / pass the hash.
+            let mut smb = if let Some(ccache) = kerberos_ccache {
+                // Kerberos: build a cifs/<host> ticket for THIS host.
+                let spn = format!("cifs/{host}");
+                let (gss_blob, session_key) =
+                    crate::transport::kerberos::kerberos_material_for(ccache, &spn, kdc)
+                        .await
+                        .map_err(|e| format!("{host} krb: {e}"))?;
+                let auth = SmbAuth::Kerberos { gss_blob: &gss_blob, session_key: &session_key };
+                connect_ipc(host, domain, user, auth).await.map_err(|e| format!("{host}: {e}"))?
+            } else {
+                let auth = match nt_hash {
+                    Some(h) => SmbAuth::Hash(h),
+                    None    => SmbAuth::Password(password),
+                };
+                connect_ipc(host, domain, user, auth).await.map_err(|e| format!("{host}: {e}"))?
             };
-            let mut smb = connect_ipc(host, domain, user, auth).await
-                .map_err(|e| format!("{host}: {e}"))?;
 
             if method.srvsvc() {
                 match srvsvc_sessions(&mut smb, host).await {
@@ -218,7 +246,7 @@ async fn is_reachable(host: &str, port_timeout_ms: u64) -> bool {
 /// enabled + pwdLastSet within the expiry window (~ SharpHound ComputerExpiryDays).
 fn is_active(c: &Computer, expiry_days: i64) -> bool {
     if !*c.properties().enabled() { return false; }
-    let pls = c.properties().pwdlastset(); // add: pub fn pwdlastset(&self) -> i64
+    let pls = c.properties().pwdlastset();
     if pls <= 0 { return false; }
     let now = chrono::Utc::now().timestamp();
     now - pls < expiry_days * 86_400
@@ -261,11 +289,10 @@ async fn enum_registry(smb: &mut SmbClient, domain: &str, user: &str,
 fn build_sid_index(users: &[User]) -> HashMap<String, String> {
     let mut idx = HashMap::with_capacity(users.len() * 2);
     for u in users {
-        let sid = u.object_identifier().clone(); // add: pub fn object_identifier(&self) -> &String
+        let sid = u.object_identifier().clone();
         if sid.is_empty() { continue; }
         let upn = u.properties().name().to_uppercase(); // SAM@DOMAIN.FQDN
         if let Some(sam) = upn.split('@').next() {
-            // bare SAM: keep the first mapping, do not let a later duplicate clobber it
             idx.entry(sam.to_string()).or_insert_with(|| sid.clone());
         }
         idx.insert(upn, sid);
@@ -336,7 +363,7 @@ fn apply_findings(
 
     // SRVSVC -> Sessions
     {
-        let s = computer.sessions_mut(); // add: pub fn sessions_mut(&mut self) -> &mut Session
+        let s = computer.sessions_mut();
         for sess in &hf.smb_sessions {
             match resolve(&sess.user, sid_index, domain) {
                 Some(user_sid) => {
@@ -352,7 +379,7 @@ fn apply_findings(
 
     // WKSSVC -> PrivilegedSessions
     {
-        let p = computer.privileged_sessions_mut(); // add: privileged_sessions_mut()
+        let p = computer.privileged_sessions_mut();
         for u in &hf.logged_on {
             match resolve(&u.username, sid_index, domain) {
                 Some(user_sid) => {
@@ -369,7 +396,7 @@ fn apply_findings(
 
     // WINREG -> RegistrySessions (SIDs already; no resolution needed)
     {
-        let r = computer.registry_sessions_mut(); // add: registry_sessions_mut()
+        let r = computer.registry_sessions_mut();
         for reg in &hf.registry {
             if reg.sid.is_empty() { continue; }
             trace!("[WINREG] {} has session on {fqdn}", reg.sid);

--- a/src/transport/gss.rs
+++ b/src/transport/gss.rs
@@ -1,0 +1,61 @@
+//! Minimal GSS-API / SPNEGO framing for a Kerberos AP-REQ carried in an SMB2
+//! SESSION_SETUP. Ported from icedracon/adhammer (crates/kerberos/src/gss.rs) <https://github.com/icedracon/adhammer>.
+
+use log::{debug, trace};
+
+fn der_len(n: usize) -> Vec<u8> {
+    if n < 0x80 {
+        vec![n as u8]
+    } else {
+        let mut b = Vec::new();
+        let mut v = n;
+        while v > 0 {
+            b.insert(0, (v & 0xff) as u8);
+            v >>= 8;
+        }
+        let mut out = vec![0x80 | b.len() as u8];
+        out.extend_from_slice(&b);
+        out
+    }
+}
+
+fn tlv(tag: u8, content: &[u8]) -> Vec<u8> {
+    let mut out = vec![tag];
+    out.extend_from_slice(&der_len(content.len()));
+    out.extend_from_slice(content);
+    out
+}
+
+const SPNEGO_OID: &[u8] = &[0x2b, 0x06, 0x01, 0x05, 0x05, 0x02];
+const KRB5_OID: &[u8] = &[0x2a, 0x86, 0x48, 0x86, 0xf7, 0x12, 0x01, 0x02, 0x02];
+
+/// Wrap a raw AP-REQ DER as the GSS-Kerberos mechToken
+/// ([APPLICATION 0] { krb5-OID, TOK_ID=0x0100, AP-REQ }).
+fn gss_krb5_aprep(ap_req_der: &[u8]) -> Vec<u8> {
+    trace!("[gss] wrapping AP-REQ ({} bytes) as GSS-Kerberos mechToken", ap_req_der.len());
+    let mut inner = Vec::new();
+    inner.extend_from_slice(&tlv(0x06, KRB5_OID));
+    inner.extend_from_slice(&[0x01, 0x00]); // TOK_ID = AP-REQ
+    inner.extend_from_slice(ap_req_der);
+    let out = tlv(0x60, &inner);
+    trace!("[gss] GSS-Kerberos mechToken = {} bytes", out.len());
+    out
+}
+
+/// SPNEGO negTokenInit carrying a Kerberos AP-REQ, for an SMB2 SESSION_SETUP.
+pub fn spnego_krb5_init(ap_req_der: &[u8]) -> Vec<u8> {
+    trace!("[gss] building SPNEGO negTokenInit from AP-REQ ({} bytes)", ap_req_der.len());
+    let mech_token = gss_krb5_aprep(ap_req_der);
+    let mech_types = tlv(0x30, &tlv(0x06, KRB5_OID));
+    let mut neg_init = Vec::new();
+    neg_init.extend_from_slice(&tlv(0xa0, &mech_types)); // mechTypes [0]
+    neg_init.extend_from_slice(&tlv(0xa2, &tlv(0x04, &mech_token))); // mechToken [2]
+    trace!("[gss] negTokenInit body = {} bytes (mechTypes + mechToken)", neg_init.len());
+    let neg_token = tlv(0xa0, &tlv(0x30, &neg_init));
+    let mut inner = Vec::new();
+    inner.extend_from_slice(&tlv(0x06, SPNEGO_OID));
+    inner.extend_from_slice(&neg_token);
+    let out = tlv(0x60, &inner);
+    debug!("[gss] SPNEGO token ready: {} bytes for SMB2 SESSION_SETUP", out.len());
+    out
+}

--- a/src/transport/kerberos.rs
+++ b/src/transport/kerberos.rs
@@ -1,0 +1,496 @@
+//! Kerberos pass-the-ticket for the SMB transport.
+//!
+//! Loads a TGT from an MIT ccache (KRB5CCNAME), requests a cifs/<host> service
+//! ticket, and builds a SPNEGO AP-REQ plus the 16-byte SMB session key for
+//! SmbClient::login_kerberos. Pure Rust: a small self-contained ccache v4
+//! parser plus picky-krb, no external ccache crate and no system GSSAPI.
+//! The TGS/AP-REQ logic is ported from icedracon/adhammer. <https://github.com/icedracon/adhammer>
+//!
+//! Logging discipline: only lengths, etypes, realm and SPN are logged (the
+//! realm/SPN already travel in clear on the wire). Session keys, subkeys and
+//! ticket/AP-REQ bytes are never logged.
+
+use anyhow::{anyhow, Context, Result};
+use log::{debug, trace, warn};
+
+use picky_asn1::bit_string::BitString;
+use picky_asn1::date::Date;
+use picky_asn1::restricted_string::Ia5String;
+use picky_asn1::wrapper::{
+    Asn1SequenceOf, BitStringAsn1, ExplicitContextTag0, ExplicitContextTag1, ExplicitContextTag2,
+    ExplicitContextTag3, ExplicitContextTag4, ExplicitContextTag5, ExplicitContextTag6,
+    ExplicitContextTag7, ExplicitContextTag8, GeneralStringAsn1, IntegerAsn1, OctetStringAsn1,
+    Optional,
+};
+use picky_krb::constants::key_usages::{
+    TGS_REP_ENC_SESSION_KEY, TGS_REQ_PA_DATA_AP_REQ_AUTHENTICATOR,
+};
+use picky_krb::constants::types::{AP_REQ_MSG_TYPE, NT_SRV_INST, TGS_REQ_MSG_TYPE};
+use picky_krb::crypto::{Cipher, CipherSuite};
+use picky_krb::data_types::{
+    Authenticator, AuthenticatorInner, Checksum, EncryptedData, EncryptionKey, KerberosTime,
+    PaData, PrincipalName, Ticket,
+};
+use picky_krb::messages::{
+    ApReq, ApReqInner, EncAsRepPart, EncTgsRepPart, KdcReq, KdcReqBody, KrbError, TgsRep, TgsReq,
+};
+
+const ETYPE_RC4_HMAC: u8 = 23;
+const ETYPE_AES256: u8 = 18;
+const PA_TGS_REQ: u8 = 0x01;
+
+/// Entry point: read the ccache, get a service ticket for `spn`, and return the
+/// SPNEGO AP-REQ blob plus the 16-byte SMB session key for login_kerberos.
+///
+/// `spn` is "cifs/<target-fqdn>"; `kdc` is the KDC host (DC FQDN or IP), port 88.
+pub async fn kerberos_material_for(
+    ccache_path: &str,
+    spn: &str,
+    kdc: &str,
+) -> Result<(Vec<u8>, [u8; 16])> {
+    let path = ccache_path.strip_prefix("FILE:").unwrap_or(ccache_path);
+    debug!("[krb] pass-the-ticket for {spn} via {kdc} (ccache: {path})");
+
+    let bytes = std::fs::read(path).with_context(|| format!("read ccache {path}"))?;
+    trace!("[krb] ccache read: {} bytes", bytes.len());
+    let creds = parse_ccache(&bytes)?;
+    trace!("[krb] ccache parsed: {} credential(s)", creds.len());
+
+    let tgt_cred = creds
+        .iter()
+        .find(|c| {
+            c.server
+                .components
+                .first()
+                .map(|c0| c0.eq_ignore_ascii_case(b"krbtgt"))
+                .unwrap_or(false)
+        })
+        .ok_or_else(|| {
+            warn!("[krb] no krbtgt credential in ccache ({} creds)", creds.len());
+            anyhow!("no TGT (krbtgt) found in ccache")
+        })?;
+
+    let realm = String::from_utf8_lossy(&tgt_cred.client.realm).to_string();
+    let comps: Vec<String> = tgt_cred
+        .client
+        .components
+        .iter()
+        .map(|c| String::from_utf8_lossy(c).to_string())
+        .collect();
+    debug!(
+        "[krb] TGT for {}@{} (session key {} bytes)",
+        comps.join("/"),
+        realm,
+        tgt_cred.key.len()
+    );
+
+    let tgt = Tgt::from_ccache_parts(
+        &tgt_cred.ticket,
+        tgt_cred.key.clone(),
+        tgt_cred.client.name_type,
+        &comps,
+        realm,
+    )?;
+
+    let st = get_service_ticket(&tgt, spn, kdc).await?;
+    let (gss_blob, session_key) = build_ap_req_gss(&st)?;
+    debug!(
+        "[krb] AP-REQ ready for {spn}: SPNEGO {} bytes, SMB session key {} bytes",
+        gss_blob.len(),
+        session_key.len()
+    );
+    Ok((gss_blob, session_key))
+}
+
+// ---- MIT ccache v4 parser (self-contained, no external crate) ---------------
+
+struct CcachePrincipal {
+    name_type: u32,
+    realm: Vec<u8>,
+    components: Vec<Vec<u8>>,
+}
+struct CcacheCred {
+    server: CcachePrincipal,
+    client: CcachePrincipal,
+    key: Vec<u8>,
+    ticket: Vec<u8>,
+}
+
+struct Reader<'a> {
+    b: &'a [u8],
+    pos: usize,
+}
+impl<'a> Reader<'a> {
+    fn new(b: &'a [u8]) -> Self {
+        Reader { b, pos: 0 }
+    }
+    fn take(&mut self, n: usize) -> Result<&'a [u8]> {
+        let s = self
+            .b
+            .get(self.pos..self.pos + n)
+            .ok_or_else(|| anyhow!("ccache truncated at offset {}", self.pos))?;
+        self.pos += n;
+        Ok(s)
+    }
+    fn u16(&mut self) -> Result<u16> {
+        Ok(u16::from_be_bytes(self.take(2)?.try_into().unwrap()))
+    }
+    fn u32(&mut self) -> Result<u32> {
+        Ok(u32::from_be_bytes(self.take(4)?.try_into().unwrap()))
+    }
+    fn u8(&mut self) -> Result<u8> {
+        Ok(self.take(1)?[0])
+    }
+    /// uint32 length + bytes.
+    fn data(&mut self) -> Result<Vec<u8>> {
+        let n = self.u32()? as usize;
+        Ok(self.take(n)?.to_vec())
+    }
+    fn principal(&mut self) -> Result<CcachePrincipal> {
+        let name_type = self.u32()?;
+        let num = self.u32()? as usize; // component count (v4: realm is separate)
+        let realm = self.data()?;
+        let mut components = Vec::with_capacity(num);
+        for _ in 0..num {
+            components.push(self.data()?);
+        }
+        Ok(CcachePrincipal { name_type, realm, components })
+    }
+}
+
+/// Parse an MIT ccache v4 (0x0504) and return its credentials.
+fn parse_ccache(bytes: &[u8]) -> Result<Vec<CcacheCred>> {
+    let mut r = Reader::new(bytes);
+    let version = r.u16()?;
+    if version != 0x0504 {
+        return Err(anyhow!(
+            "unsupported ccache version {version:#06x} (need v4 0x0504)"
+        ));
+    }
+    trace!("[krb] ccache v4 header ok");
+    // v4 header block: uint16 header_len + tagged fields (skip it).
+    let hlen = r.u16()? as usize;
+    r.take(hlen)?;
+    // default principal.
+    let _default = r.principal()?;
+    // credentials until EOF.
+    let mut creds = Vec::new();
+    while r.pos < bytes.len() {
+        let client = r.principal()?;
+        let server = r.principal()?;
+        // keyblock: uint16 keytype, uint16 etype, uint16 keylen, key.
+        let _keytype = r.u16()?;
+        let _etype = r.u16()?;
+        let klen = r.u16()? as usize;
+        let key = r.take(klen)?.to_vec();
+        // times: authtime, starttime, endtime, renew_till.
+        let _ = (r.u32()?, r.u32()?, r.u32()?, r.u32()?);
+        let _is_skey = r.u8()?;
+        let _tktflags = r.u32()?;
+        // addresses.
+        let na = r.u32()? as usize;
+        for _ in 0..na {
+            let _t = r.u16()?;
+            let _ = r.data()?;
+        }
+        // authdata.
+        let nad = r.u32()? as usize;
+        for _ in 0..nad {
+            let _t = r.u16()?;
+            let _ = r.data()?;
+        }
+        // ticket + second_ticket.
+        let ticket = r.data()?;
+        let _second = r.data()?;
+        trace!(
+            "[krb] ccache cred: server={}",
+            server
+                .components
+                .iter()
+                .map(|c| String::from_utf8_lossy(c).to_string())
+                .collect::<Vec<_>>()
+                .join("/")
+        );
+        creds.push(CcacheCred { server, client, key, ticket });
+    }
+    Ok(creds)
+}
+
+// ---- crypto helpers ----------------------------------------------------------
+
+fn aes256() -> Box<dyn Cipher> {
+    CipherSuite::Aes256CtsHmacSha196.cipher()
+}
+fn session_etype(key: &[u8]) -> u8 {
+    if key.len() == 16 { ETYPE_RC4_HMAC } else { ETYPE_AES256 }
+}
+fn enc_session(key: &[u8], usage: i32, data: &[u8]) -> Result<Vec<u8>> {
+    if key.len() == 16 {
+        Ok(ms_pac_forge::checksum::rc4_encrypt(key, usage, data, None))
+    } else {
+        aes256().encrypt(key, usage, data).map_err(|e| anyhow!("encrypt (AES): {e}"))
+    }
+}
+fn dec_session(key: &[u8], usage: i32, ct: &[u8]) -> Result<Vec<u8>> {
+    if key.len() == 16 {
+        ms_pac_forge::checksum::rc4_decrypt(key, usage, ct).map_err(|e| anyhow!("decrypt (RC4): {e}"))
+    } else {
+        aes256().decrypt(key, usage, ct).map_err(|e| anyhow!("decrypt (AES): {e}"))
+    }
+}
+
+// ---- ASN.1 helpers ------------------------------------------------------------
+
+fn krb_string(s: &str) -> Result<GeneralStringAsn1> {
+    let ia5 = Ia5String::from_string(s.to_owned())
+        .map_err(|_| anyhow!("non-IA5 Kerberos component: {s:?}"))?;
+    Ok(GeneralStringAsn1::from(ia5))
+}
+fn principal(name_type: u8, parts: &[&str]) -> Result<PrincipalName> {
+    let strings = parts.iter().map(|p| krb_string(p)).collect::<Result<Vec<_>>>()?;
+    Ok(PrincipalName {
+        name_type: ExplicitContextTag0::from(IntegerAsn1(vec![name_type])),
+        name_string: ExplicitContextTag1::from(Asn1SequenceOf::from(strings)),
+    })
+}
+fn now_kerberos_time() -> KerberosTime {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+    let (y, m, d) = civil_from_days(secs.div_euclid(86_400));
+    let tod = secs.rem_euclid(86_400);
+    KerberosTime::from(
+        Date::new(y, m, d, (tod / 3600) as u8, ((tod % 3600) / 60) as u8, (tod % 60) as u8).unwrap(),
+    )
+}
+fn far_future_time() -> KerberosTime {
+    KerberosTime::from(Date::new(2037, 9, 13, 2, 48, 5).unwrap())
+}
+fn civil_from_days(z: i64) -> (u16, u8, u8) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    ((y + i64::from(m <= 2)) as u16, m as u8, d as u8)
+}
+fn nonce() -> IntegerAsn1 {
+    let mut n = [0u8; 4];
+    rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut n);
+    n[0] &= 0x7f;
+    IntegerAsn1(n.to_vec())
+}
+fn encrypted_data(etype: u8, cipher: Vec<u8>) -> EncryptedData {
+    EncryptedData {
+        etype: ExplicitContextTag0::from(IntegerAsn1(vec![etype])),
+        kvno: Optional::from(None),
+        cipher: ExplicitContextTag2::from(OctetStringAsn1(cipher)),
+    }
+}
+fn krb_err(resp: &[u8]) -> String {
+    match picky_asn1_der::from_bytes::<KrbError>(resp) {
+        Ok(err) => format!("KDC error {}", err.0.error_code.0),
+        Err(e) => format!("decode: {e}"),
+    }
+}
+
+// ---- KDC network exchange (TCP/88) --------------------------------------------
+
+async fn kdc_exchange(kdc: &str, request: &[u8]) -> Result<Vec<u8>> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let addr = if kdc.contains(':') { kdc.to_string() } else { format!("{kdc}:88") };
+
+    trace!("[krb] KDC connect {addr}, sending {} bytes", request.len());
+    let mut stream = tokio::net::TcpStream::connect(&addr).await.map_err(|e| {
+        warn!("[krb] KDC connect {addr} failed: {e}");
+        e
+    })?;
+    let mut framed = Vec::with_capacity(request.len() + 4);
+    framed.extend_from_slice(&(request.len() as u32).to_be_bytes());
+    framed.extend_from_slice(request);
+    stream.write_all(&framed).await?;
+
+    let mut len = [0u8; 4];
+    stream.read_exact(&mut len).await?;
+    let n = u32::from_be_bytes(len) as usize;
+    if n == 0 || n > 4 * 1024 * 1024 {
+        return Err(anyhow!("implausible KDC response length {n}"));
+    }
+    let mut buf = vec![0u8; n];
+    stream.read_exact(&mut buf).await?;
+    trace!("[krb] KDC response: {} bytes", n);
+    Ok(buf)
+}
+
+// ---- Tgt / ServiceTicket ------------------------------------------------------
+
+struct Tgt {
+    ticket: Ticket,
+    session_key: Vec<u8>,
+    cname: PrincipalName,
+    crealm: String,
+}
+
+impl Tgt {
+    fn from_ccache_parts(
+        ticket_der: &[u8],
+        session_key: Vec<u8>,
+        name_type: u32,
+        components: &[String],
+        realm: String,
+    ) -> Result<Self> {
+        let ticket: Ticket = picky_asn1_der::from_bytes(ticket_der)
+            .map_err(|e| anyhow!("decode ticket DER: {e}"))?;
+        let parts: Vec<&str> = components.iter().map(|s| s.as_str()).collect();
+        let cname = principal(name_type as u8, &parts)?;
+        Ok(Tgt { ticket, session_key, cname, crealm: realm })
+    }
+}
+
+struct ServiceTicket {
+    ticket: Ticket,
+    session_key: Vec<u8>,
+    crealm: String,
+    cname: PrincipalName,
+}
+
+// ---- TGS-REQ + AP-REQ ---------------------------------------------------------
+
+fn ap_req_padata(tgt: &Tgt) -> Result<PaData> {
+    let authenticator = Authenticator::from(AuthenticatorInner {
+        authenticator_vno: ExplicitContextTag0::from(IntegerAsn1(vec![5])),
+        crealm: ExplicitContextTag1::from(krb_string(&tgt.crealm)?),
+        cname: ExplicitContextTag2::from(tgt.cname.clone()),
+        cksum: Optional::from(None),
+        cusec: ExplicitContextTag4::from(IntegerAsn1(vec![0])),
+        ctime: ExplicitContextTag5::from(now_kerberos_time()),
+        subkey: Optional::from(None),
+        seq_number: Optional::from(None),
+        authorization_data: Optional::from(None),
+    });
+    let auth_der = picky_asn1_der::to_vec(&authenticator).map_err(|e| anyhow!("authenticator: {e}"))?;
+    let enc_auth = enc_session(&tgt.session_key, TGS_REQ_PA_DATA_AP_REQ_AUTHENTICATOR, &auth_der)?;
+    let ap_req = ApReq::from(ApReqInner {
+        pvno: ExplicitContextTag0::from(IntegerAsn1(vec![5])),
+        msg_type: ExplicitContextTag1::from(IntegerAsn1(vec![AP_REQ_MSG_TYPE])),
+        ap_options: ExplicitContextTag2::from(BitStringAsn1::from(BitString::with_bytes(vec![0, 0, 0, 0]))),
+        ticket: ExplicitContextTag3::from(tgt.ticket.clone()),
+        authenticator: ExplicitContextTag4::from(encrypted_data(session_etype(&tgt.session_key), enc_auth)),
+    });
+    let ap_der = picky_asn1_der::to_vec(&ap_req).map_err(|e| anyhow!("AP-REQ: {e}"))?;
+    Ok(PaData {
+        padata_type: ExplicitContextTag1::from(IntegerAsn1(vec![PA_TGS_REQ])),
+        padata_data: ExplicitContextTag2::from(OctetStringAsn1(ap_der)),
+    })
+}
+
+fn build_tgs_req(realm: &str, sname: PrincipalName, padatas: Vec<PaData>, etypes: &[u8]) -> Result<TgsReq> {
+    let body = KdcReqBody {
+        kdc_options: ExplicitContextTag0::from(BitStringAsn1::from(BitString::with_bytes(vec![0x40, 0x81, 0x00, 0x00]))),
+        cname: Optional::from(None),
+        realm: ExplicitContextTag2::from(krb_string(realm)?),
+        sname: Optional::from(Some(ExplicitContextTag3::from(sname))),
+        from: Optional::from(None),
+        till: ExplicitContextTag5::from(far_future_time()),
+        rtime: Optional::from(None),
+        nonce: ExplicitContextTag7::from(nonce()),
+        etype: ExplicitContextTag8::from(Asn1SequenceOf::from(
+            etypes.iter().map(|e| IntegerAsn1(vec![*e])).collect::<Vec<_>>(),
+        )),
+        addresses: Optional::from(None),
+        enc_authorization_data: Optional::from(None),
+        additional_tickets: Optional::from(None),
+    };
+    Ok(TgsReq::from(KdcReq {
+        pvno: ExplicitContextTag1::from(IntegerAsn1(vec![5])),
+        msg_type: ExplicitContextTag2::from(IntegerAsn1(vec![TGS_REQ_MSG_TYPE])),
+        padata: Optional::from(Some(ExplicitContextTag3::from(Asn1SequenceOf::from(padatas)))),
+        req_body: ExplicitContextTag4::from(body),
+    }))
+}
+
+async fn get_service_ticket(tgt: &Tgt, spn: &str, kdc: &str) -> Result<ServiceTicket> {
+    debug!("[krb] TGS-REQ for {spn} (realm {})", tgt.crealm);
+    let comps: Vec<&str> = spn.split('/').collect();
+    let req = build_tgs_req(
+        &tgt.crealm,
+        principal(NT_SRV_INST, &comps)?,
+        vec![ap_req_padata(tgt)?],
+        &[ETYPE_AES256, ETYPE_RC4_HMAC],
+    )?;
+    let raw = picky_asn1_der::to_vec(&req).map_err(|e| anyhow!("TGS-REQ encode: {e}"))?;
+    let resp = kdc_exchange(kdc, &raw).await?;
+
+    let tgs_rep: TgsRep = picky_asn1_der::from_bytes(&resp).map_err(|_| {
+        let err = krb_err(&resp);
+        warn!("[krb] TGS-REP error for {spn}: {err}");
+        anyhow!("TGS-REP: {err}")
+    })?;
+
+    let enc = &tgs_rep.0.enc_part.0.cipher.0 .0;
+    let plain = dec_session(&tgt.session_key, TGS_REP_ENC_SESSION_KEY, enc)?;
+    let kdc_rep = picky_asn1_der::from_bytes::<EncTgsRepPart>(&plain)
+        .map(|p| p.0)
+        .or_else(|_| picky_asn1_der::from_bytes::<EncAsRepPart>(&plain).map(|p| p.0))
+        .map_err(|e| anyhow!("decode EncKDCRepPart: {e}"))?;
+    let session_key = kdc_rep.key.0.key_value.0 .0.clone();
+    debug!(
+        "[krb] service ticket for {spn}: session key {} bytes (etype {})",
+        session_key.len(),
+        session_etype(&session_key)
+    );
+
+    Ok(ServiceTicket {
+        ticket: tgs_rep.0.ticket.0.clone(),
+        session_key,
+        crealm: tgt.crealm.clone(),
+        cname: tgt.cname.clone(),
+    })
+}
+
+fn build_ap_req_gss(st: &ServiceTicket) -> Result<(Vec<u8>, [u8; 16])> {
+    let mut subkey = [0u8; 16];
+    rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut subkey);
+    trace!(
+        "[krb] building AP-REQ (fresh AES128 subkey, service etype {})",
+        session_etype(&st.session_key)
+    );
+
+    let mut gss_cksum = Vec::new();
+    gss_cksum.extend_from_slice(&16u32.to_le_bytes());
+    gss_cksum.extend_from_slice(&[0u8; 16]);
+    gss_cksum.extend_from_slice(&0x0000_003cu32.to_le_bytes());
+
+    let authenticator = Authenticator::from(AuthenticatorInner {
+        authenticator_vno: ExplicitContextTag0::from(IntegerAsn1(vec![5])),
+        crealm: ExplicitContextTag1::from(krb_string(&st.crealm)?),
+        cname: ExplicitContextTag2::from(st.cname.clone()),
+        cksum: Optional::from(Some(ExplicitContextTag3::from(Checksum {
+            cksumtype: ExplicitContextTag0::from(IntegerAsn1(vec![0x00, 0x80, 0x03])),
+            checksum: ExplicitContextTag1::from(OctetStringAsn1(gss_cksum)),
+        }))),
+        cusec: ExplicitContextTag4::from(IntegerAsn1(vec![0])),
+        ctime: ExplicitContextTag5::from(now_kerberos_time()),
+        subkey: Optional::from(Some(ExplicitContextTag6::from(EncryptionKey {
+            key_type: ExplicitContextTag0::from(IntegerAsn1(vec![17])),
+            key_value: ExplicitContextTag1::from(OctetStringAsn1(subkey.to_vec())),
+        }))),
+        seq_number: Optional::from(None),
+        authorization_data: Optional::from(None),
+    });
+    let auth_der = picky_asn1_der::to_vec(&authenticator).map_err(|e| anyhow!("authenticator: {e}"))?;
+    let enc_auth = enc_session(&st.session_key, 11, &auth_der)?;
+
+    let ap_req = ApReq::from(ApReqInner {
+        pvno: ExplicitContextTag0::from(IntegerAsn1(vec![5])),
+        msg_type: ExplicitContextTag1::from(IntegerAsn1(vec![AP_REQ_MSG_TYPE])),
+        ap_options: ExplicitContextTag2::from(BitStringAsn1::from(BitString::with_bytes(vec![0, 0, 0, 0]))),
+        ticket: ExplicitContextTag3::from(st.ticket.clone()),
+        authenticator: ExplicitContextTag4::from(encrypted_data(session_etype(&st.session_key), enc_auth)),
+    });
+    let ap_der = picky_asn1_der::to_vec(&ap_req).map_err(|e| anyhow!("AP-REQ: {e}"))?;
+    Ok((super::gss::spnego_krb5_init(&ap_der), subkey))
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -2,7 +2,13 @@
 //!
 //! * `ldap`: LDAP/LDAPS connection, authentication (NTLM, pass the hash,
 //!   Kerberos) and paged search used for the main collection phase.
-//! * `smb`: SMB and MS RPC transport (SRVSVC, WKSSVC, WINREG) used by the
-//!   sessions module to enumerate live sessions on domain machines.
+//! * `smb`: SMB and MS RPC transport. IPC$ pipes (SRVSVC, WKSSVC, WINREG) for
+//!   the sessions module, and the SYSVOL share for GPO file collection.
+//! * `gss`: minimal SPNEGO framing for a Kerberos AP-REQ carried in an SMB2
+//!   SESSION_SETUP.
+//! * `kerberos`: pass the ticket helper. Loads a TGT from a ccache, requests a
+//!   cifs/<host> service ticket and builds the AP-REQ for SMB Kerberos auth.
 pub mod ldap;
 pub mod smb;
+pub mod gss;
+pub mod kerberos;

--- a/src/transport/smb.rs
+++ b/src/transport/smb.rs
@@ -26,6 +26,9 @@ pub enum SmbAuth<'a> {
     Password(&'a str),
     /// Pass the hash with a raw 16 byte NT hash.
     Hash(&'a [u8; 16]),
+    /// Pass-the-ticket: SPNEGO AP-REQ blob + 16 byte SMB session key
+    /// already built for this host's cifs/<host> SPN.
+    Kerberos { gss_blob: &'a [u8], session_key: &'a [u8; 16] },
 }
 
 /// UNC of the IPC$ share (MS RPC pipes).
@@ -72,6 +75,13 @@ pub async fn connect_authenticated(
             smb.login(host, domain, user, password).await.map_err(|e| {
                 error!("[{host}] SMB auth failed for {domain}\\{user}: {e}");
                 anyhow::anyhow!("auth: {e}")
+            })?;
+        }
+        SmbAuth::Kerberos { gss_blob, session_key } => {
+            trace!("[{host}] SMB SESSION_SETUP with Kerberos (pass the ticket)");
+            smb.login_kerberos(gss_blob, session_key).await.map_err(|e| {
+                error!("[{host}] SMB Kerberos auth failed: {e}");
+                anyhow::anyhow!("auth(krb): {e}")
             })?;
         }
     }


### PR DESCRIPTION
## Summary

Adds a Kerberos pass-the-ticket path to the SMB transport, so the sessions module (SRVSVC / WKSSVC / WINREG over IPC$) and GPO SYSVOL collection can authenticate with a Kerberos ticket, alongside the existing password and pass-the-hash paths. Closes #61.

## Problem

`transport::smb` supported only `SmbAuth::Password` (NTLMv2) and `SmbAuth::Hash` (pass-the-hash). The LDAP side already speaks Kerberos, so an operator running with a TGT could collect over LDAP but fell back to NTLM for the SMB/RPC and SYSVOL paths, inconsistent, and broken where NTLM is disabled.

## Approach

- New `SmbAuth::Kerberos { gss_blob, session_key }` variant, handled in `connect_authenticated` via `SmbClient::login_kerberos`, with the same trace/debug/warn/error logging as the other paths.
- New `transport::kerberos`: reads a TGT from an MIT ccache (`KRB5CCNAME`), sends a TGS-REQ for `cifs/<host>`, and builds a SPNEGO AP-REQ plus the 16-byte SMB session key.
- New `transport::gss`: minimal SPNEGO framing for the AP-REQ carried in the SMB2 SESSION_SETUP.
- The AP-REQ authenticator carries a fresh AES128 subkey with mutual-auth off, so the server adopts it as the session key and SMB signing is deterministic.
- Wired from `--kerberos`: sessions builds a ticket per host (SPN is per target), GPO SYSVOL builds one for the DC.

## Implementation notes

- Pure Rust, no system GSSAPI and no FFI: a small self-contained ccache v4 parser plus `picky-krb` for the TGS/AP-REQ. No dependency on an external ccache crate (avoids a `nom`/`memchr` version conflict with `zip`).
- The Kerberos TGS/AP-REQ and GSS/SPNEGO logic is ported from **icedracon/adhammer** (`crates/kerberos`); credited in the source headers. Same author as `smb2-client` and `picky-krb`.
- Kerberos material is rebuilt per host because the AP-REQ targets that host's `cifs/<host>` SPN, unlike password/hash which are reusable.
- Logging discipline: only lengths, etypes, realm and SPN are logged (they already travel in clear on the wire). Session keys, subkeys and ticket/AP-REQ bytes are never logged.