### PR TITLE
feat: certificate authentication (Pass-the-Certificate) for LDAP collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ rusthound-ce*
 .vscode
 .rusthound-cache
 *.ccache
+*.crt
+*.key
+*.pfx

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,8 +14,18 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "generic-array",
+]
+
+[[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -25,8 +35,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -35,12 +56,26 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "ghash 0.5.1",
  "subtle",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2b8006a0c83f52b62ba44a97b58bf76fe2f70a329e588f67f89691d93d498f"
+dependencies = [
+ "aead 0.6.1",
+ "aes 0.9.3",
+ "cipher 0.5.2",
+ "ctr 0.10.1",
+ "ctutils",
+ "ghash 0.6.0",
 ]
 
 [[package]]
@@ -49,7 +84,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
 dependencies = [
- "aes",
+ "aes 0.8.4",
 ]
 
 [[package]]
@@ -364,12 +399,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -396,7 +449,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -463,8 +525,19 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.6",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -511,9 +584,9 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
  "dbl",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -523,6 +596,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "cms"
+version = "0.3.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758d5272932ff167e96ec9641a04d96ab1901cccc5ea9f47c15b4cbaa6f9ea53"
+dependencies = [
+ "const-oid 0.10.2",
+ "der 0.8.2",
+ "spki 0.8.0",
+ "x509-cert",
 ]
 
 [[package]]
@@ -561,6 +652,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +672,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -647,7 +750,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf1e6e5492f8f0830c37f301f6349e0dac8b2466e4fe89eef90e9eef906cd046"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
 ]
 
 [[package]]
@@ -674,6 +777,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,7 +801,25 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -701,7 +831,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -740,14 +870,14 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea6d00208aa00426820d6e4797ac94fd4252af1feacc046d9b0177796b4259e"
 dependencies = [
- "aes",
- "des",
+ "aes 0.8.4",
+ "des 0.8.1",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "md-5",
  "ms-ndr",
  "ntlmssp",
- "sha2",
+ "sha2 0.10.9",
  "smb2-client",
  "thiserror 2.0.20",
  "tokio",
@@ -761,8 +891,21 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
- "pem-rfc7468",
+ "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
+dependencies = [
+ "const-oid 0.10.2",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -795,6 +938,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,7 +974,16 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "des"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -829,10 +992,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -858,12 +1033,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
- "digest",
+ "der 0.7.10",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -872,7 +1047,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.2",
  "signature",
 ]
 
@@ -886,7 +1061,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -905,13 +1080,13 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
  "hkdf",
- "pem-rfc7468",
- "pkcs8",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -986,6 +1161,12 @@ name = "find-msvc-tools"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -1159,7 +1340,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
- "polyval",
+ "polyval 0.6.2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval 0.7.3",
 ]
 
 [[package]]
@@ -1203,7 +1393,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -1212,7 +1402,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1253,6 +1452,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1483,8 +1691,18 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
+ "block-padding 0.3.3",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding 0.4.2",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1739,7 +1957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1748,7 +1966,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da5ac363534dce5fabf69949225e174fbf111a498bf0ff794c8ea1fba9f3dda"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1810,7 +2028,7 @@ checksum = "a413d7f67644e2f3a18d333b5b43632ff2ca48b6c14ccd4f287a15723484d546"
 dependencies = [
  "anyhow",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "md-5",
  "md4",
  "picky-asn1",
@@ -1835,7 +2053,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "356c05d7a1def1ef3ab09a432e86e1f08a30ec5657f7dc022ebabfd901b31ad7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "md-5",
  "md4",
  "rand 0.8.5",
@@ -1980,6 +2198,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "p12-keystore"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02686a966a6d270eb3e87178c70323a30a62741e59b37e542ff029fb774afa47"
+dependencies = [
+ "cbc 0.2.1",
+ "cms",
+ "der 0.8.2",
+ "des 0.9.0",
+ "hex",
+ "hmac 0.13.0",
+ "pkcs12",
+ "pkcs5",
+ "pkcs8 0.11.0",
+ "rand 0.10.2",
+ "rc2 0.9.0",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "thiserror 2.0.20",
+ "x509-parser 0.18.1",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,7 +2229,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2000,7 +2241,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2014,7 +2255,7 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2046,9 +2287,19 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
- "sha1",
+ "digest 0.10.7",
+ "hmac 0.12.1",
+ "sha1 0.10.6",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -2056,6 +2307,15 @@ name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -2072,34 +2332,34 @@ version = "7.0.0-rc.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33807ce79d4b14a8918e968a8606e5142ddc6aec933acef79de0bd769cae5fb1"
 dependencies = [
- "aes",
- "aes-gcm",
+ "aes 0.8.4",
+ "aes-gcm 0.10.3",
  "aes-kw",
  "base64",
- "cbc",
- "des",
- "digest",
+ "cbc 0.1.2",
+ "des 0.8.1",
+ "digest 0.10.7",
  "ed25519-dalek",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http",
  "md-5",
  "num-bigint-dig",
  "p256",
  "p384",
  "p521",
- "pbkdf2",
+ "pbkdf2 0.12.2",
  "picky-asn1",
  "picky-asn1-der",
  "picky-asn1-x509",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "rc2",
+ "rc2 0.8.1",
  "rsa",
  "serde",
  "serde_json",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "sha3",
  "thiserror 1.0.69",
  "x25519-dalek",
@@ -2152,21 +2412,21 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd326177336b27707c6f969e14f57a54d6b521ce95cce55785ce02525052783"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "byteorder",
- "cbc",
+ "cbc 0.1.2",
  "crypto",
- "des",
- "hmac",
+ "des 0.8.1",
+ "hmac 0.12.1",
  "num-bigint-dig",
  "oid",
- "pbkdf2",
+ "pbkdf2 0.12.2",
  "picky-asn1",
  "picky-asn1-der",
  "picky-asn1-x509",
  "rand 0.8.5",
  "serde",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -2177,21 +2437,21 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e78a55491723b0a10bc2c02709a8d92d74ef674fe1b569cb4a08bac3d105487"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "byteorder",
- "cbc",
+ "cbc 0.1.2",
  "crypto",
- "des",
- "hmac",
+ "des 0.8.1",
+ "hmac 0.12.1",
  "num-bigint-dig",
  "oid",
- "pbkdf2",
+ "pbkdf2 0.12.2",
  "picky-asn1",
  "picky-asn1-der",
  "picky-asn1-x509",
  "rand 0.8.5",
  "serde",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -2214,9 +2474,40 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs12"
+version = "0.2.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8059bd79345d1d1c125656025814704bab5cdd204b1cefd5fab59b0fdd7476d2"
+dependencies = [
+ "cms",
+ "const-oid 0.10.2",
+ "der 0.8.2",
+ "digest 0.11.3",
+ "spki 0.8.0",
+ "x509-cert",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d440a804ec8d6fafbb6b84471e013286658d373248927692ab3366686220ca"
+dependencies = [
+ "aes 0.9.3",
+ "aes-gcm 0.11.1",
+ "cbc 0.2.1",
+ "der 0.8.2",
+ "pbkdf2 0.13.0",
+ "scrypt",
+ "sha2 0.11.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -2225,8 +2516,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.2",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -2244,7 +2545,18 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.1",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -2482,7 +2794,16 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62c64daa8e9438b84aaae55010a93f396f8e60e3911590fcba770d04643fc1dd"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "rc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceda21af1ae61033b63175653a1af86cae399d79cd03ca80ba347eb3a6c4a7fe"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -2575,7 +2896,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -2610,17 +2931,17 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sha1",
+ "sha1 0.10.6",
  "signature",
- "spki",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -2672,6 +2993,7 @@ dependencies = [
  "nom",
  "obfstr",
  "once_cell",
+ "p12-keystore",
  "picky",
  "picky-asn1",
  "picky-asn1-der",
@@ -2682,9 +3004,12 @@ dependencies = [
  "regex",
  "reqwest",
  "rpassword",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.10.6",
  "smb2-client",
  "tokio",
  "trust-dns-resolver",
@@ -2731,6 +3056,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2765,6 +3099,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2780,15 +3124,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scrypt"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
+dependencies = [
+ "cfg-if",
+ "pbkdf2 0.13.0",
+ "salsa20",
+ "sha2 0.11.0",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -2895,7 +3251,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2906,7 +3273,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2915,7 +3293,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -2937,7 +3315,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2965,12 +3343,12 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e819de60ba1c46009f7e80894c388377fb8d2f9975cca37d9434dfa3f0247b"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "cmac",
- "hmac",
+ "hmac 0.12.1",
  "ntlmssp",
  "rand 0.8.5",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -3009,7 +3387,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.2",
 ]
 
 [[package]]
@@ -3025,7 +3413,7 @@ dependencies = [
  "cfg-if",
  "crypto-mac",
  "futures",
- "hmac",
+ "hmac 0.12.1",
  "lazy_static",
  "md-5",
  "md4",
@@ -3043,8 +3431,8 @@ dependencies = [
  "rustls",
  "serde",
  "serde_derive",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "time",
  "tokio",
  "tracing",
@@ -3439,8 +3827,18 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -4065,6 +4463,17 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
+dependencies = [
+ "const-oid 0.10.2",
+ "der 0.8.2",
+ "spki 0.8.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,12 @@ picky-asn1      = "0.10"
 picky-asn1-der  = "0.5"
 ms-pac-forge    = "0.1.3"
 rand = "0.8"
+# rustls pieces (aligned with what ldap3 0.12.1 pulls: rustls 0.23, pki-types 1).
+rustls           = { version = "0.23", default-features = false, features = ["ring", "std"] }
+rustls-pemfile   = "2"
+rustls-pki-types = "1"
+# PKCS#12 (.pfx) parsing, pure Rust.
+p12-keystore = "0.3"
 
 [features]
 noargs = ["winreg"] # Only available for Windows

--- a/HELP.md
+++ b/HELP.md
@@ -12,6 +12,7 @@
   - [How to build documentation?](#how-to-build-documentation)
 - [Usage](#usage)
   - [Simple usage](#simple-usage)
+  - [Pass-the-Certificate](#pass-the-certificate-certificate-authentication)
   - [Using disk instead of memory](#using-disk-instead-of-memory)
   - [Module FQDN resolver](#module-fqdn-resolver)
 
@@ -223,9 +224,15 @@ OPTIONAL VALUES:
   -H, --hashes <hashes>              NT hash for pass-the-hash authentication (NTLM), accept [NTHASH, :NTHASH, LMHASH:NTHASH]
   -f, --ldapfqdn <ldapfqdn>          Domain Controller FQDN like: DC01.DOMAIN.LOCAL or just DC01
   -i, --ldapip <ldapip>              Domain Controller IP address like: 192.168.1.10
-  -P, --ldapport <ldapport>          LDAP port [default: 389]
+  -P, --ldapport <ldapport>          LDAP port [default: 389, or 636 with --ldaps]
   -n, --name-server <name-server>    Alternative IP address name server to use for DNS queries
   -o, --output <output>              Output directory where you would like to save JSON files [default: ./]
+
+CERTIFICATE AUTHENTICATION:
+      --pfx <pfx>            PFX/PKCS#12 client certificate for certificate authentication (Pass-the-Certificate). Uses StartTLS by default, or LDAPS with --ldaps
+      --pfx-pass <pfx-pass>  Password protecting the PFX file (optional)
+      --crt <crt>            PEM client certificate for certificate authentication (use with --key)
+      --key <key>            PEM private key for certificate authentication (use with --crt)
 
 OPTIONAL FLAGS:
   -c, --collectionmethod [<COLLECTIONMETHOD>]
@@ -286,6 +293,63 @@ export KRB5CCNAME="/tmp/jeor.mormont.ccache"
 rusthound-ce -d sevenkingdoms.local -f kingslanding -k -z
 # Kerberos authentication (Windows)
 rusthound-ce.exe -d sevenkingdoms.local -f kingslanding -k -z
+```
+
+## Pass-the-Certificate (certificate authentication)
+
+RustHound-CE can authenticate over LDAP with a client certificate instead of a
+password, NT hash, or Kerberos ticket. The Domain Controller maps the
+certificate to an account at the TLS layer (Schannel), so no bind credentials
+are needed. This is useful when PKINIT is not supported and works where LDAP
+Channel Binding is enforced.
+
+By default certificate auth uses **LDAP 389 + StartTLS**; add `--ldaps` to use
+**LDAPS 636** instead (some DCs only accept one of the two — try `--ldaps` if
+StartTLS is refused). The certificate must carry the target account's SID for
+strong certificate mapping (KB5014754). SMB-based modules (sessions and
+GPO/SYSVOL) are skipped in certificate mode, since no SMB credentials are
+available; LDAP collection runs fully.
+
+### Requesting a certificate with Certipy
+
+```bash
+# Request a certificate for a user you control (adjust CA and template; run `certipy find` first)
+certipy req -u user@essos.local -p 'password' -target braavos.essos.local -ca 'ESSOS-CA' -template User
+
+# Or forge one for another principal (ESC1); the UPN and SID must match the target
+certipy req -u attacker@essos.local -p 'password' -target braavos.essos.local -ca 'ESSOS-CA' \
+    -template User -upn daenerys.targaryen@essos.local -sid S-1-5-21-...-1112
+```
+
+### Converting the PFX to PEM (crt + key)
+
+RustHound-CE accepts a PFX directly (`--pfx` / `--pfx-pass`), but PEM is the most
+reliable path across Certipy versions. Extract the certificate and the key:
+
+```bash
+# With Certipy
+certipy cert -pfx daenerys.targaryen.pfx -nokey  -out daenerys.crt
+certipy cert -pfx daenerys.targaryen.pfx -nocert -out daenerys.key
+
+# Or with OpenSSL
+openssl pkcs12 -in daenerys.targaryen.pfx -nokeys  -out daenerys.crt -nodes
+openssl pkcs12 -in daenerys.targaryen.pfx -nocerts -out daenerys.key -nodes
+```
+
+### Usage
+
+```bash
+# Certificate auth over LDAPS (636), PEM cert + key
+rusthound-ce -d ESSOS.LOCAL -f MEEREEN.ESSOS.LOCAL --crt daenerys.crt --key daenerys.key -o /tmp/demo --ldaps -c All -z -v
+
+# Certificate auth over StartTLS (389, default when --ldaps is omitted)
+rusthound-ce -d ESSOS.LOCAL -f MEEREEN.ESSOS.LOCAL --crt daenerys.crt --key daenerys.key -o /tmp/demo -c All -z -v
+
+# Certificate auth with a PFX instead of PEM
+rusthound-ce -d ESSOS.LOCAL -f MEEREEN.ESSOS.LOCAL --pfx daenerys.targaryen.pfx --ldaps -o /tmp/demo -c All -z -v
+
+# PFX protected by a password
+rusthound-ce -d ESSOS.LOCAL -f MEEREEN.ESSOS.LOCAL --pfx daenerys.targaryen.pfx --pfx-pass 'P@ssw0rd' --ldaps -o /tmp/demo -c All -z
 ```
 
 ## Using disk instead of memory

--- a/src/args.rs
+++ b/src/args.rs
@@ -39,6 +39,14 @@ pub struct Options {
     pub resume: bool,
 }
 
+impl Options {
+    /// True when authenticating with a client certificate (no SMB credentials
+    /// are available, so SMB-based modules must be skipped).
+    pub fn uses_cert(&self) -> bool {
+        self.pfx.is_some() || self.crt.is_some()
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum CollectionMethod {
     All,            // LDAP + sessions (all three RPC paths) + SMB on SYSVOL

--- a/src/args.rs
+++ b/src/args.rs
@@ -25,6 +25,11 @@ pub struct Options {
     pub fqdn_resolver: bool,
     pub hashes: Option<String>,
     pub kerberos: bool,
+    // Certificate authentication (Pass-the-Certificate / Schannel)
+    pub pfx: Option<String>,
+    pub pfx_pass: Option<String>,
+    pub crt: Option<String>,
+    pub key: Option<String>,
     pub zip: bool,
     pub verbose: log::LevelFilter,
     pub ldap_filter: String,
@@ -116,7 +121,7 @@ fn cli() -> Command {
     .arg(Arg::new("ldapport")
         .short('P')
         .long("ldapport")
-        .help("LDAP port [default: 389]")
+        .help("LDAP port [default: 389, or 636 with --ldaps]")
         .required(false)
         .value_parser(value_parser!(String))
     )
@@ -131,6 +136,31 @@ fn cli() -> Command {
         .short('o')
         .long("output")
         .help("Output directory where you would like to save JSON files [default: ./]")
+        .required(false)
+        .value_parser(value_parser!(String))
+    )
+    .next_help_heading("CERTIFICATE AUTHENTICATION")
+    .arg(Arg::new("pfx")
+        .long("pfx")
+        .help("PFX/PKCS#12 client certificate for certificate authentication (Pass-the-Certificate). Uses StartTLS by default, or LDAPS with --ldaps")
+        .required(false)
+        .value_parser(value_parser!(String))
+    )
+    .arg(Arg::new("pfx-pass")
+        .long("pfx-pass")
+        .help("Password protecting the PFX file (optional)")
+        .required(false)
+        .value_parser(value_parser!(String))
+    )
+    .arg(Arg::new("crt")
+        .long("crt")
+        .help("PEM client certificate for certificate authentication (use with --key)")
+        .required(false)
+        .value_parser(value_parser!(String))
+    )
+    .arg(Arg::new("key")
+        .long("key")
+        .help("PEM private key for certificate authentication (use with --crt)")
         .required(false)
         .value_parser(value_parser!(String))
     )
@@ -265,6 +295,13 @@ pub fn extract_args() -> Options {
         .get_one::<bool>("kerberos")
         .map(|s| s.to_owned())
         .unwrap_or(false);
+
+    // Certificate authentication paths
+    let pfx = matches.get_one::<String>("pfx").cloned();
+    let pfx_pass = matches.get_one::<String>("pfx-pass").cloned();
+    let crt = matches.get_one::<String>("crt").cloned();
+    let key = matches.get_one::<String>("key").cloned();
+
     let v = match matches.get_count("v") {
         0 => log::LevelFilter::Info,
         1 => log::LevelFilter::Debug,
@@ -307,6 +344,10 @@ pub fn extract_args() -> Options {
         dns_tcp,
         fqdn_resolver,
         kerberos,
+        pfx,
+        pfx_pass,
+        crt,
+        key,
         zip: z,
         verbose: v,
         ldap_filter: ldap_filter.to_string(),
@@ -370,6 +411,10 @@ pub fn auto_args() -> Options {
         fqdn_resolver: false,
         hashes: None,
         kerberos: true,
+        pfx: None,
+        pfx_pass: None,
+        crt: None,
+        key: None,
         zip: true,
         verbose: log::LevelFilter::Info,
         ldap_filter: "(objectClass=*)".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,13 +36,19 @@
 //!   -H, --hashes <hashes>              NT hash for pass-the-hash authentication (NTLM), accept [NTHASH, :NTHASH, LMHASH:NTHASH]
 //!   -f, --ldapfqdn <ldapfqdn>          Domain Controller FQDN like: DC01.DOMAIN.LOCAL or just DC01
 //!   -i, --ldapip <ldapip>              Domain Controller IP address like: 192.168.1.10
-//!   -P, --ldapport <ldapport>          LDAP port [default: 389]
+//!   -P, --ldapport <ldapport>          LDAP port [default: 389, or 636 with --ldaps]
 //!   -n, --name-server <name-server>    Alternative IP address name server to use for DNS queries
 //!   -o, --output <output>              Output directory where you would like to save JSON files [default: ./]
 //! 
+//! CERTIFICATE AUTHENTICATION:
+//!       --pfx <pfx>            PFX/PKCS#12 client certificate for certificate authentication (Pass-the-Certificate). Uses StartTLS by default, or LDAPS with --ldaps
+//!       --pfx-pass <pfx-pass>  Password protecting the PFX file (optional)
+//!       --crt <crt>            PEM client certificate for certificate authentication (use with --key)
+//!       --key <key>            PEM private key for certificate authentication (use with --crt)
+//! 
 //! OPTIONAL FLAGS:
 //!   -c, --collectionmethod [<COLLECTIONMETHOD>]
-//!           Which information to collect. Supported: All (LDAP,SMB,HTTP requests), DCOnly (no computer connections, only LDAP requests). (default: All) [possible values: All, DCOnly]
+//!           Which information to collect. Supported: All (LDAP, SMB, HTTP), DCOnly (LDAP + SYSVOL, no member-machine connections), Session (user sessions over RPC), RegistryOnly (sessions over WINREG), LdapOnly (LDAP only, no machine or SYSVOL) (default: All) [possible values: All, DCOnly, Session, RegistryOnly, LdapOnly]
 //!       --ldap-filter <ldap-filter>
 //!           Use custom ldap-filter default is : (objectClass=*)
 //!       --ldaps

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     common_args.password.as_deref(),
                     common_args.hashes.as_deref(),
                     common_args.kerberos,
+                    common_args.pfx.as_deref(),
+                    common_args.pfx_pass.as_deref(),
+                    common_args.crt.as_deref(),
+                    common_args.key.as_deref(),
                     &common_args.ldap_filter,
                     &mut cache_writer,
                 )
@@ -112,6 +116,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     common_args.password.as_deref(),
                     common_args.hashes.as_deref(),
                     common_args.kerberos,
+                    common_args.pfx.as_deref(),
+                    common_args.pfx_pass.as_deref(),
+                    common_args.crt.as_deref(),
+                    common_args.key.as_deref(),
                     &common_args.ldap_filter,
                     &mut ldap_results,
                 )

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -14,7 +14,17 @@ use crate::modules::adcs::probe_enterpriseca_esc8;
 use crate::modules::gpo::sysvol::collect_sysvol_targets;
 
 /// Function to run all modules requested
-pub async fn run_modules(common_args: &Options, ad: &mut ADResults) -> Result<(), Box<dyn Error>> {
+pub async fn run_modules(
+    common_args: &Options,
+    ad: &mut ADResults
+) -> Result<(), Box<dyn Error>> {
+
+    let cert_auth = common_args.uses_cert();
+    if cert_auth {
+        log::warn!("Certificate authentication in use: skipping SMB-based modules \
+                    (sessions and GPO/SYSVOL) no SMB credentials available.");
+    }
+
     // [MODULE - RESOLVER] Resolve FQDN to IP address.
     if common_args.fqdn_resolver {
         resolver::resolv::resolving_all_fqdn(
@@ -32,7 +42,7 @@ pub async fn run_modules(common_args: &Options, ad: &mut ADResults) -> Result<()
     // - SRVSVC / NetrSessionEnum - inbound SMB sessions (client IP + username).
     // - WKSSVC / NetrWkstaUserEnum - users with an active logon context on the machine.
     // - WINREG / HKEY_USERS - SIDs of loaded profile hives (= logged-on users).
-    if common_args.collection_method.does_sessions() {
+    if common_args.collection_method.does_sessions() && !cert_auth {
         sessions::run(common_args, &ad.users, &mut ad.computers).await?;
     }
 
@@ -55,7 +65,7 @@ pub async fn run_modules(common_args: &Options, ad: &mut ADResults) -> Result<()
 
     // [MODULE - GPO SYSVOL] read GptTmpl.inf / Groups.xml off the DC SYSVOL share.
     // <#47 Privileges> and <#56 LocalGroup>. DC-side I/O, so it also runs in DCOnly.
-    if common_args.collection_method.does_gpo() {
+    if common_args.collection_method.does_gpo() && !cert_auth {
         let computer_scope = gpo::sysvol::ComputerGpoScope::from_gpos(&ad.gpos);
         let sysvol = match collect_sysvol_targets(common_args, &computer_scope).await {
             Ok(v) => v,

--- a/src/transport/cert.rs
+++ b/src/transport/cert.rs
@@ -1,0 +1,141 @@
+//! Client-certificate TLS configuration for certificate authentication
+//! (Pass-the-Certificate / Schannel) over LDAPS.
+//!
+//! Builds a rustls `ClientConfig` that presents a client certificate, matching
+//! the rustls backend ldap3 uses (`tls-rustls-ring`). It is attached to
+//! `LdapConnSettings::set_config` when a certificate is provided. AD then maps
+//! the certificate to an account at the TLS layer (implicit Schannel mapping),
+//! so no explicit bind is performed.
+//!
+//! Accepts a PFX/PKCS#12 file (`--pfx` / `--pfx-pass`) or a PEM cert + key pair
+//! (`--crt` / `--key`). TLS 1.2 is enforced for compatibility with older DCs
+//! (some Windows Server 2016 DCs do not answer a TLS 1.3 ClientHello on LDAPS).
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, Context, Result};
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
+use rustls::version::TLS12;
+use rustls::{ClientConfig, DigitallySignedStruct, SignatureScheme};
+
+/// Build a rustls `ClientConfig` presenting the given client certificate.
+pub fn build_client_config(
+    pfx: Option<&str>,
+    pfx_pass: Option<&str>,
+    crt: Option<&str>,
+    key: Option<&str>,
+) -> Result<Arc<ClientConfig>> {
+    let (certs, key_der) = match (pfx, crt, key) {
+        (Some(pfx_path), _, _) => load_pfx(pfx_path, pfx_pass.unwrap_or(""))?,
+        (None, Some(crt_path), Some(key_path)) => load_pem(crt_path, key_path)?,
+        _ => return Err(anyhow!("certificate auth requires --pfx, or both --crt and --key")),
+    };
+
+    // TLS 1.2 only: some Server 2016 DCs do not answer a TLS 1.3 ClientHello on LDAPS.
+    let config = ClientConfig::builder_with_protocol_versions(&[&TLS12])
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoServerVerify))
+        .with_client_auth_cert(certs, key_der)
+        .map_err(|e| anyhow!("client auth cert: {e}"))?;
+
+    Ok(Arc::new(config))
+}
+
+/// Load cert chain + private key from a PFX/PKCS#12 file.
+fn load_pfx(
+    path: &str,
+    password: &str,
+) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
+    use p12_keystore::{KeyStore, KeyStoreEntry, Pkcs12ImportPolicy};
+
+    let data = std::fs::read(path).with_context(|| format!("read pfx {path}"))?;
+    let ks = KeyStore::from_pkcs12(&data, password, Pkcs12ImportPolicy::default())
+        .map_err(|e| anyhow!("parse pfx (convert to PEM with `openssl pkcs12` if this fails): {e:?}"))?;
+
+    for (_alias, entry) in ks.entries() {
+        if let KeyStoreEntry::PrivateKeyChain(chain) = entry {
+            let key = PrivateKeyDer::try_from(chain.key().as_der().to_vec())
+                .map_err(|e| anyhow!("pfx private key: {e}"))?;
+            let certs: Vec<CertificateDer<'static>> = chain
+                .certs()
+                .iter()
+                .map(|c| CertificateDer::from(c.as_der().to_vec()))
+                .collect();
+            if certs.is_empty() {
+                return Err(anyhow!("pfx has a key but no certificate"));
+            }
+            return Ok((certs, key));
+        }
+    }
+    Err(anyhow!("no private-key entry found in pfx"))
+}
+
+/// Load cert chain (crt) + private key (key) from PEM files.
+fn load_pem(
+    crt: &str,
+    key: &str,
+) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
+    let crt_bytes = std::fs::read(crt).with_context(|| format!("read crt {crt}"))?;
+    let key_bytes = std::fs::read(key).with_context(|| format!("read key {key}"))?;
+
+    let certs = rustls_pemfile::certs(&mut &crt_bytes[..])
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|e| anyhow!("parse crt: {e}"))?;
+    if certs.is_empty() {
+        return Err(anyhow!("no certificate in {crt}"));
+    }
+
+    let key_der = rustls_pemfile::private_key(&mut &key_bytes[..])
+        .map_err(|e| anyhow!("parse key: {e}"))?
+        .ok_or_else(|| anyhow!("no private key in {key}"))?;
+
+    Ok((certs, key_der))
+}
+
+/// ServerCertVerifier that accepts everything, consistent with the
+/// `set_no_tls_verify(true)` already used by RustHound-CE for LDAPS.
+#[derive(Debug)]
+struct NoServerVerify;
+
+impl ServerCertVerifier for NoServerVerify {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp: &[u8],
+        _now: UnixTime,
+    ) -> std::result::Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::ED25519,
+        ]
+    }
+}

--- a/src/transport/ldap.rs
+++ b/src/transport/ldap.rs
@@ -18,6 +18,7 @@ use crate::utils::format::domain_to_dc;
 use colored::Colorize;
 use indicatif::ProgressBar;
 use ldap3::adapters::{Adapter, EntriesOnly};
+use ldap3::exop::WhoAmI;
 use ldap3::{adapters::PagedResults, controls::RawControl, LdapConnAsync, LdapConnSettings};
 use ldap3::{Scope, SearchEntry};
 use log::{info, debug, error, trace};
@@ -38,22 +39,121 @@ pub async fn ldap_search<S: Storage<LdapSearchEntry>>(
     password: Option<&str>,
     hashes: Option<&str>,
     kerberos: bool,
+    // Certificate authentication (Pass-the-Certificate / Schannel)
+    pfx: Option<&str>,
+    pfx_pass: Option<&str>,
+    crt: Option<&str>,
+    key: Option<&str>,
     ldapfilter: &str,
     storage: &mut S,
 ) -> Result<usize, Box<dyn Error>> {
-    // Construct LDAP args
+    // Certificate authentication is enabled when a PFX or a CRT+KEY is provided.
+    let use_cert = pfx.is_some() || crt.is_some();
+
+    // Certificate auth transport:
+    //   - with --ldaps : LDAPS 636, implicit Schannel mapping, no bind.
+    //   - without      : LDAP 389 + StartTLS, SASL EXTERNAL bind (default).
+    // So StartTLS is used for cert auth unless --ldaps is explicitly requested.
+    let starttls = use_cert && !ldaps;
+
+    // Non-certificate modes keep the user-provided `ldaps` value unchanged;
+    // cert over LDAPS forces the ldaps scheme, cert over StartTLS keeps 389.
+    let effective_ldaps = if use_cert { !starttls } else { ldaps };
+
+    // Certificate transport needs a port consistent with the scheme, otherwise
+    // `prepare_ldap_url` (which also treats port 636 as LDAPS) would build an
+    // ldaps:// URL while StartTLS is enabled, or vice-versa. When the user does
+    // not pass an explicit port, pick the default for the chosen cert transport:
+    //   StartTLS -> 389, LDAPS -> 636. A user-supplied port is respected.
+    let effective_port = if use_cert {
+        port.or(Some(if starttls { 389 } else { 636 }))
+    } else {
+        port
+    };
+
+    // Construct LDAP args (URL scheme follows effective_ldaps)
     let ldap_args = ldap_constructor(
-        ldaps, ip, port, domain, ldapfqdn, username, password, hashes, kerberos,
+        effective_ldaps, ip, effective_port, domain, ldapfqdn, username, password, hashes, kerberos, use_cert,
     )?;
 
-    // LDAP connection
-    let consettings = LdapConnSettings::new()
+    // LDAP connection settings
+    let mut consettings = LdapConnSettings::new()
         .set_conn_timeout(std::time::Duration::from_secs(10))
         .set_no_tls_verify(true);
+
+    // Attach the client certificate config when doing certificate auth.
+    if use_cert {
+        let config = crate::transport::cert::build_client_config(pfx, pfx_pass, crt, key)?;
+        consettings = consettings.set_config(config);
+        if starttls {
+            consettings = consettings.set_starttls(true);
+        }
+    }
+
     let (conn, mut ldap) = LdapConnAsync::with_settings(consettings, &ldap_args.s_url).await?;
     ldap3::drive!(conn);
 
-    if let Some(ref ntlm_password) = ldap_args.s_ntlm_password {
+    if use_cert {
+        // Pass-the-Certificate. AD maps the client certificate to an account at
+        // the TLS layer (Schannel). Over LDAPS the mapping is implicit (no bind);
+        // over StartTLS we authenticate with SASL EXTERNAL. In both cases the
+        // mapped identity is confirmed with a whoami before collection.
+        if starttls {
+            debug!("Trying certificate authentication (StartTLS + SASL EXTERNAL)");
+            match ldap.sasl_external_bind().await.and_then(|r| r.success()) {
+                Ok(_) => {}
+                Err(err) => {
+                    error!(
+                        "Certificate SASL EXTERNAL bind failed on {} Active Directory. \
+                         Some DCs refuse it over StartTLS; try LDAPS. Reason: {err}\n",
+                        domain.to_uppercase().bold().red()
+                    );
+                    process::exit(0x0100);
+                }
+            }
+        } else {
+            debug!("Trying certificate authentication (LDAPS, implicit Schannel mapping)");
+        }
+
+        // Confirm the mapped identity via whoami (both transports).
+        match ldap.extended(WhoAmI).await.map(|r| r.success()) {
+            Ok(Ok((exop, _))) => {
+                let who = exop
+                    .val
+                    .as_ref()
+                    .map(|v| String::from_utf8_lossy(v).to_string())
+                    .unwrap_or_default();
+                if who.is_empty() {
+                    error!(
+                        "Certificate not mapped by {} Active Directory (empty whoami). \
+                         Check the certificate SID and the DC enforcement mode (KB5014754).\n",
+                        domain.to_uppercase().bold().red()
+                    );
+                    process::exit(0x0100);
+                }
+                info!(
+                    "Connected to {} Active Directory via certificate as {}!",
+                    domain.to_uppercase().bold().green(),
+                    who.bold().green()
+                );
+                info!("Starting data collection...");
+            }
+            Ok(Err(err)) => {
+                error!(
+                    "Certificate authentication failed on {} Active Directory. Reason: {err}\n",
+                    domain.to_uppercase().bold().red()
+                );
+                process::exit(0x0100);
+            }
+            Err(err) => {
+                error!(
+                    "Certificate authentication request failed on {} Active Directory. Reason: {err}\n",
+                    domain.to_uppercase().bold().red()
+                );
+                process::exit(0x0100);
+            }
+        }
+    } else if let Some(ref ntlm_password) = ldap_args.s_ntlm_password {
         debug!("Trying to connect with sasl_ntlm_bind() function (NTLM pass-the-hash)");
         let res = ldap
             .sasl_ntlm_bind(&ldap_args.s_username, ntlm_password)
@@ -154,15 +254,6 @@ pub async fn ldap_search<S: Storage<LdapSearchEntry>>(
             let controls = vec![sd_flags, show_deleted];
             ldap.with_controls(controls.to_owned());
 
-            // Prepare filter
-            // let mut _s_filter: &str = "";
-            // if cn.contains("Configuration") {
-            //     _s_filter = "(|(objectclass=pKIEnrollmentService)(objectclass=pkicertificatetemplate)(objectclass=subschema)(objectclass=certificationAuthority)(objectclass=container))";
-            // } else {
-            //     _s_filter = "(objectClass=*)";
-            // }
-            //let _s_filter = "(objectClass=*)";
-            //let _s_filter = "(objectGuid=*)";
             info!("Ldap filter : {}", ldapfilter.bold().green());
             let _s_filter = ldapfilter;
 
@@ -213,10 +304,6 @@ pub async fn ldap_search<S: Storage<LdapSearchEntry>>(
                 }
             }
         }
-        // // If no result exit program
-        // if rs.is_empty() {
-        //     process::exit(0x0100);
-        // }
 
         ldap.unbind().await?;
     }
@@ -227,12 +314,10 @@ pub async fn ldap_search<S: Storage<LdapSearchEntry>>(
     drop(ldap);
     if total == 0 {
         error!("No LDAP objects found! Exiting...");
-        // std::fs::remove_file(cache_path)?; // TODO: return error so we can cleanup cache
         process::exit(0x0100);
     }
 
     storage.flush()?;
-
 
     // Return the vector with the result
     Ok(total)
@@ -249,6 +334,7 @@ struct LdapArgs {
 }
 
 /// Function to prepare LDAP arguments.
+#[allow(clippy::too_many_arguments)]
 fn ldap_constructor(
     ldaps: bool,
     ip: Option<&str>,
@@ -259,6 +345,8 @@ fn ldap_constructor(
     password: Option<&str>,
     hashes: Option<&str>,
     kerberos: bool,
+    // When true, no username/password is needed (identity comes from the cert)
+    use_cert: bool,
 ) -> Result<LdapArgs, Box<dyn Error>> {
     // Prepare ldap url
     let s_url = prepare_ldap_url(ldaps, ip, port, domain);
@@ -268,10 +356,10 @@ fn ldap_constructor(
 
     let use_ntlm = hashes.is_some();
 
-    // Username prompt
+    // Username prompt (skipped for certificate auth: identity comes from the cert)
     let mut s = String::new();
     let mut _s_username: String;
-    if username.is_none() && !kerberos {
+    if username.is_none() && !kerberos && !use_cert {
         print!("Username: ");
         io::stdout().flush()?;
         stdin()
@@ -326,9 +414,9 @@ fn ldap_constructor(
         None => None,
     };
 
-    // Password prompt (skip when using NTLM hash)
+    // Password prompt (skip for NTLM hash, Kerberos, and certificate auth)
     let mut _s_password: String = String::new();
-    if !use_ntlm && !_s_username.contains("not set") && !kerberos {
+    if !use_ntlm && !_s_username.contains("not set") && !kerberos && !use_cert {
         _s_password = match password {
             Some(p) => p.to_owned(),
             None => rpassword::prompt_password("Password: ").unwrap_or("not set".to_string()),
@@ -353,7 +441,9 @@ fn ldap_constructor(
     debug!("Domain: {}", domain);
     debug!("Username: {}", _s_username);
     debug!("Email: {}", s_email.to_lowercase());
-    if use_ntlm {
+    if use_cert {
+        debug!("Auth: certificate (Pass-the-Certificate)");
+    } else if use_ntlm {
         debug!("Auth: NTLM pass-the-hash");
     } else {
         debug!("Password: {}", _s_password);

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -8,7 +8,11 @@
 //!   SESSION_SETUP.
 //! * `kerberos`: pass the ticket helper. Loads a TGT from a ccache, requests a
 //!   cifs/<host> service ticket and builds the AP-REQ for SMB Kerberos auth.
+//! * `cert`: rustls client config carrying a client certificate (PFX/PEM) for
+//!   certificate authentication over LDAPS.
+//! 
 pub mod ldap;
 pub mod smb;
 pub mod gss;
 pub mod kerberos;
+pub mod cert;


### PR DESCRIPTION
## Summary

Adds certificate authentication for the LDAP collection (closes #31). RustHound-CE can now authenticate over LDAP with a client certificate, a PFX (`--pfx` / `--pfx-pass`) or a PEM cert and key (`--crt` / `--key`), instead of a password, NT hash, or Kerberos ticket.

## Problem

Some environments do not allow password/NTLM/Kerberos collection but do expose LDAP over Schannel with client-certificate mapping (Pass-the-Certificate). This is common when PKINIT is unavailable (e.g. the DC certificate lacks the Smart Card Logon EKU) but the DC still maps client certificates at the TLS layer. There was no way to run a collection with only a certificate.

## Approach

- New `transport::cert` builds a rustls `ClientConfig` that presents the client certificate (PFX via `p12-keystore`, PEM via `rustls-pemfile`), matching the `ldap3` rustls backend already in use. TLS 1.2 is enforced for compatibility with older DCs.
- `ldap_search` gains a certificate branch, tried before the existing NTLM / simple-bind / GSSAPI paths and guarded by the presence of a certificate. All existing authentication modes are unchanged.
- Two transports, selected automatically:
  - **LDAP 389 + StartTLS** (default): the client presents the certificate during StartTLS and binds with SASL EXTERNAL.
  - **LDAPS 636** (`--ldaps`): the DC maps the certificate implicitly at the TLS layer, no bind. Some DCs accept only one of the two; `--ldaps` selects the direct-LDAPS path.
- The mapped identity is confirmed with a whoami (parsed defensively) before collection starts.
- The port follows the chosen transport when not set explicitly (389 for StartTLS, 636 for LDAPS), so the URL scheme and StartTLS never disagree.

## Scope

- New CLI options `--pfx`, `--pfx-pass`, `--crt`, `--key` (help group "CERTIFICATE AUTHENTICATION").
- SMB-based modules (sessions over RPC and GPO/SYSVOL) are skipped with a warning under certificate auth, since no SMB credentials are available; LDAP collection and the ESC8 HTTP probe are unaffected.
- The certificate must carry the target account's SID for strong certificate mapping (KB5014754).
- No change to the output format or to existing authentication modes.

## Dependencies

- `rustls-pemfile` (PEM parsing) and `p12-keystore` (PFX parsing), both pure Rust. `rustls` / `rustls-pki-types` are already pulled by `ldap3/tls-rustls-ring`.

## Testing

- `cargo build --release` and `cargo clippy --all-targets` pass.
- Validated end-to-end against a GOAD lab (essos.local, DC MEEREEN / Server 2016):
  `rusthound-ce -d ESSOS.LOCAL -f MEEREEN.ESSOS.LOCAL --crt daenerys.crt --key daenerys.key --ldaps -c All`
  authenticates as the mapped identity (`u:ESSOS\daenerys.targaryen`) and collects normally. Existing password / pass-the-hash / Kerberos paths were re-checked and unchanged.

## Notes and credits

This path was prototyped and validated in a standalone tool, [passthecert-rs](https://github.com/g0h4n/PassTheCert-rs), whose approach and Schannel handling are themselves ported from [[AlmondOffSec/PassTheCert](https://github.com/AlmondOffSec/PassTheCert)](https://github.com/AlmondOffSec/PassTheCert) (by [[@lowercase_drm](https://github.com/ThePirateWhoSmellsOfSunflowers)](https://github.com/ThePirateWhoSmellsOfSunflowers)). Only the certificate authentication needed for collection is included here — the offensive action set stays in the separate tool.

Documentation: a "Pass-the-Certificate" section is added to HELP.md (requesting a certificate with Certipy, converting PFX to PEM, and usage examples).