### PR TITLE
fix: SMB collection failures and ESC8 detection false negatives

### DIFF
--- a/src/modules/adcs/esc8.rs
+++ b/src/modules/adcs/esc8.rs
@@ -34,14 +34,22 @@ const MV_AV_CHANNEL_BINDINGS: u16 = 0x000A;
 
 /// Anonymous NTLM Type 1 Negotiate token.
 ///
-/// Flags encoded (little-endian `0xa2088207`):
-///  NTLMSSP_NEGOTIATE_UNICODE            (0x00000001)
-///  NTLMSSP_NEGOTIATE_OEM                (0x00000002)
-///  NTLMSSP_REQUEST_TARGET               (0x00000004)
-///  NTLMSSP_NEGOTIATE_NTLM               (0x00000200)
+/// Flags encoded (little-endian `0xa0088207`):
+///  NTLMSSP_NEGOTIATE_UNICODE                  (0x00000001)
+///  NTLMSSP_NEGOTIATE_OEM                      (0x00000002)
+///  NTLMSSP_REQUEST_TARGET                     (0x00000004)
+///  NTLMSSP_NEGOTIATE_NTLM                     (0x00000200)
+///  NTLMSSP_NEGOTIATE_ALWAYS_SIGN              (0x00008000)
 ///  NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY (0x00080000)
-///  NTLMSSP_NEGOTIATE_128                (0x20000000)
-///  NTLMSSP_NEGOTIATE_56                 (0x80000000)
+///  NTLMSSP_NEGOTIATE_128                      (0x20000000)
+///  NTLMSSP_NEGOTIATE_56                       (0x80000000)
+///
+/// NEGOTIATE_VERSION (0x02000000) MUST NOT be set here: MS-NLMP §2.2.1.1
+/// requires an 8-byte Version block when that flag is present, and this
+/// minimal 32-byte token omits it. IIS/HTTP.sys rejects a Type 1 that claims
+/// NEGOTIATE_VERSION without a Version block: it never returns a Type 2
+/// challenge, so the EPA probe cannot see MsvAvChannelBindings and the CA
+/// is silently reported as not ESC8-vulnerable.
 ///
 /// Domain and Workstation fields are empty; no version block.
 const NTLM_NEGOTIATE: &[u8] = &[
@@ -49,12 +57,13 @@ const NTLM_NEGOTIATE: &[u8] = &[
     0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00,
     // MessageType = 1
     0x01, 0x00, 0x00, 0x00,
-    // NegotiateFlags (LE 0xa2088207)
-    0x07, 0x82, 0x08, 0xa2,
-    // DomainNameFields: Len=0, MaxLen=0, Offset=32
-    0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00,
-    // WorkstationFields: Len=0, MaxLen=0, Offset=32
-    0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00,
+    // NegotiateFlags LE 0xa0088207 (no NEGOTIATE_VERSION 0x02000000: without a Version block
+    // present, IIS rejects the Type 1 as malformed and never returns a Type 2 challenge).
+    0x07, 0x82, 0x08, 0xa0,
+    // DomainNameFields: empty
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // WorkstationFields: empty
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 ];
 
 // Status string values matching BloodHound CE expected format.

--- a/src/modules/gpo/sysvol.rs
+++ b/src/modules/gpo/sysvol.rs
@@ -66,9 +66,9 @@ fn is_gpo_guid(name: &str) -> bool {
 
 /// Build the SMB target and credentials, then collect GPO directives off SYSVOL.
 pub async fn collect_sysvol_targets(common_args: &Options, scope: &ComputerGpoScope) -> anyhow::Result<Vec<SysvolGpo>> {
-    use crate::transport::smb::{nt_hash_from_str, SmbAuth};
+    use crate::transport::smb::{nt_hash_from_str, smb_user, SmbAuth};
 
-    let user = common_args.username.clone().unwrap_or_default();
+    let user = smb_user(common_args.username.as_deref().unwrap_or_default());
     let password = common_args.password.clone().unwrap_or_default();
     let nt = common_args.hashes.as_deref().and_then(nt_hash_from_str);
 

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -6,7 +6,7 @@ pub mod sessions;
 
 use std::error::Error;
 
-use rayon::prelude::*;
+use futures::future;
 
 use crate::api::ADResults;
 use crate::args::{CollectionMethod, Options};
@@ -38,7 +38,12 @@ pub async fn run_modules(common_args: &Options, ad: &mut ADResults) -> Result<()
 
     // [MODULE - ESC8] Web enrollment probe on all enterprise CAs.
     // Skipped in DCOnly mode (no direct machine connections allowed).
-    // Uses rayon to probe all CAs in parallel (each probe has a 5 s timeout).
+    // Each probe's blocking reqwest client runs via tokio::task::spawn_blocking
+    // on Tokio's dedicated blocking thread pool. Building/dropping a
+    // reqwest::blocking::Client (which owns its own nested Tokio runtime)
+    // panics on drop if done on a thread already inside an async context; the
+    // previous rayon par_iter_mut could run the closure on the calling Tokio
+    // worker thread itself (e.g. with a single CA), which was the crash.
     if !matches!(common_args.collection_method, CollectionMethod::DCOnly)
         && !matches!(common_args.collection_method, CollectionMethod::LdapOnly)
         && !ad.enterprisecas.is_empty()
@@ -47,10 +52,25 @@ pub async fn run_modules(common_args: &Options, ad: &mut ADResults) -> Result<()
             "Starting ESC8 web enrollment probe on {} CA(s)...",
             ad.enterprisecas.len()
         );
-        ad.enterprisecas.par_iter_mut().for_each(|ca| {
-            let esc8 = probe_enterpriseca_esc8(ca.dns_host());
-            ca.apply_esc8(esc8.http_enrollment_endpoints);
-        });
+        let hosts: Vec<String> = ad
+            .enterprisecas
+            .iter()
+            .map(|ca| ca.dns_host().to_string())
+            .collect();
+        let probes = future::join_all(hosts.into_iter().map(|host| {
+            tokio::task::spawn_blocking(move || probe_enterpriseca_esc8(&host))
+        }))
+        .await;
+        for (ca, probe) in ad.enterprisecas.iter_mut().zip(probes) {
+            match probe {
+                Ok(esc8) => ca.apply_esc8(esc8.http_enrollment_endpoints),
+                Err(join_err) => log::warn!(
+                    "[adcs] ESC8 probe task for {} did not complete ({}), skipping",
+                    ca.dns_host(),
+                    join_err
+                ),
+            }
+        }
     }
 
     // [MODULE - GPO SYSVOL] read GptTmpl.inf / Groups.xml off the DC SYSVOL share.

--- a/src/modules/sessions/mod.rs
+++ b/src/modules/sessions/mod.rs
@@ -40,7 +40,7 @@ use dcerpc::rrp::{RegistryClient, RegistrySession};
 use dcerpc::srvsvc::SrvsvcClient;
 use dcerpc::wkssvc::{WkstaUser, WkstaUserClient};
 use smb2_client::SmbClient;
-use crate::transport::smb::{connect_ipc, open_rpc_pipe, SmbAuth};
+use crate::transport::smb::{connect_ipc, open_rpc_pipe, smb_user, SmbAuth};
 
 use crate::args::{CollectionMethod, Options};
 use crate::objects::common::UserComputerSession;
@@ -95,7 +95,7 @@ pub async fn run(
     // 3) Enumerate with bounded concurrency (throttle) instead of a serial loop.
     let sem = Arc::new(Semaphore::new(DEFAULT_CONCURRENCY));
     let domain = args.domain.clone();
-    let user = args.username.clone().unwrap_or_default();
+    let user = smb_user(args.username.as_deref().unwrap_or_default());
     let password = args.password.clone().unwrap_or_default();
     let nt_hash = parse_hash(args.hashes.as_deref()); // "LM:NT" | ":NT" | "NT" -> [u8;16]
     let method = args.collection_method.clone();

--- a/src/transport/smb.rs
+++ b/src/transport/smb.rs
@@ -205,3 +205,21 @@ pub fn nt_hash_from_str(raw: &str) -> Option<[u8; 16]> {
     }
     Some(out)
 }
+
+/// Normalize a raw `-u/--ldapusername` value into the bare NTLM username
+/// expected by SMB SESSION_SETUP.
+///
+/// `-u` is documented/used as `user@domain.local`, which is correct for LDAP
+/// but not for SMB: `smb.login()`/`login_hash()` build the NTLM identity
+/// themselves as `domain + "\" + user`, so passing a UPN-suffixed or
+/// `DOMAIN\`-prefixed value through unmodified produces an invalid identity
+/// (e.g. `SCAFFOLD.HTB\j.harris@scaffold.htb`) and the DC replies
+/// STATUS_LOGON_FAILURE. Strip both forms so callers always pass a bare
+/// sAMAccountName-style username. LDAP's own bind logic (transport::ldap)
+/// already handles its format correctly and must not use this helper.
+pub fn smb_user(raw: &str) -> String {
+    let raw = raw.trim();
+    let no_upn = raw.split('@').next().unwrap_or(raw);
+    let bare = no_upn.rsplit('\\').next().unwrap_or(no_upn);
+    bare.to_string()
+}


### PR DESCRIPTION
Three fixes to collection reliability and correctness, discovered while running rusthound-ce against a lab AD environment. Each is a separate commit; the two "ESC8" ones are unrelated code paths despite the shared area, so it should be reasonable to cherry-pick them individually if that's preferred.

## 1. SMB auth with UPN usernames

Passing `-u user@domain.local` — the exact form the `--help` text suggests — always failed SMB auth with `STATUS_LOGON_FAILURE` (0xc000006d), which then propagated to a "SMB connectivity" cascade in the sessions and GPO/SYSVOL modules.

`sessions/mod.rs` and `gpo/sysvol.rs` were forwarding the raw `-u` value to `smb2-client`'s `login()` / `login_hash()`. Those functions build the NTLM identity themselves as `domain\user`, so a UPN-suffixed value produced the invalid identity `SCAFFOLD.HTB\j.harris@scaffold.htb`, which the DC rejects. The LDAP transport already normalizes this shape on its side; the SMB path just didn't.

Added a small `smb_user()` helper in `transport::smb` that trims a UPN suffix and/or `DOMAIN\` prefix, and routed the two SMB call sites through it. Bare usernames pass through untouched. The LDAP transport is not touched.

## 2. ESC8 probe panic that killed the whole run

`run_modules` is async, and the ESC8 probe was using `rayon::par_iter_mut` with `reqwest::blocking::Client` inside the closure. Rayon's work-stealing can execute that closure directly on the calling thread — which is already inside the Tokio runtime — and dropping `reqwest::blocking`'s own nested runtime from there panics with:

> Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.

This took down the whole process before any JSON/zip output was written. Reproduced on every run against a single-CA target.

Replaced with `tokio::task::spawn_blocking` per CA collected via `futures::future::join_all`, which runs the blocking work on Tokio's dedicated blocking pool where nested runtimes are safe. A `JoinError` (a spawned closure panicking / being cancelled) is logged and skipped rather than propagating as a fatal, matching this module's existing "log and continue" style. `Cargo.toml` is untouched — `futures` and `tokio` (with `rt-multi-thread`) are already dependencies; `rayon` is still used elsewhere so it stays.

Confirmed via `git diff` against `v2.5.9` that the same code was present there and `tokio`/`reqwest` pinned versions are identical, so this is a latent thread-scheduling hazard rather than a regression from a recent change.

## 3. ESC8 false negatives from a malformed NTLM Type 1 blob

Discovered by cross-checking rusthound-ce's ESC8 output against certipy on the same lab CA. certipy flagged the CA as `Vulnerable_NtlmHttpsEndpointWithoutEpa`; rusthound-ce came back with an empty `HttpEnrollmentEndpoints` array. Same target, opposite verdicts.

The anonymous NTLM Type 1 blob the HTTPS probe sends had `NTLMSSP_NEGOTIATE_VERSION` (0x02000000) set in `NegotiateFlags` but did not include the 8-byte Version block that MS-NLMP §2.2.1.1 requires whenever that flag is set. IIS / HTTP.sys treats that as a malformed message: it never routes the request to the NTLM handler and never returns a Type 2 challenge — you get a generic IIS-layer 401 with an empty `WWW-Authenticate: NTLM` header instead. Since the probe was looking for a Type 2 to parse `MsvAvChannelBindings` out of, it always fell through to "not vulnerable" for every CA, regardless of the CA's actual configuration. Silent false negative in a security-detection code path.

Traced the difference by routing rusthound-ce's request through mitmproxy and comparing the exact bytes to a working `curl` request. The Type 1 flag byte was the only meaningful difference; a minimal reqwest reproducer with the corrected blob got the Type 2 challenge back on the first try.

The fix drops `NEGOTIATE_VERSION` from the flags (`0xa2088207` → `0xa0088207`) and zeroes the now-unused DomainName/Workstation payload offsets, which were pointing one byte past the empty payload anyway. Message length is unchanged (32 bytes). Doc comment updated to accurately list the flags actually set and to explain why VERSION must not be there.

## Verification

Ran against a live DC (Windows Server 2022, one Enterprise CA with HTTPS web enrollment + EPA disabled):

- `-u user@domain.local -p ... -c All`: full collection completes, all 13 JSON files written. Repeated three times back-to-back with identical output.
- `-u user -k -c All` (Kerberos pass-the-ticket via ccache): same clean completion via the new SMB Kerberos path.
- ESC8 detection with the fix in place: CA correctly reported as `Vulnerable_NtlmHttpsEndpointWithoutEpa`, `ADCSWebEnrollmentEPA=false`, matching certipy.
- `cargo test`: 106 unit + 1 lib test pass; existing `base64_roundtrip_ntlm_negotiate` still passes since it doesn't assert specific bytes.
- `cargo build`: clean, no new warnings on the touched files.

## Files changed

- `src/transport/smb.rs` — new `smb_user()` helper
- `src/modules/sessions/mod.rs` — route SMB username through `smb_user()`
- `src/modules/gpo/sysvol.rs` — route SMB username through `smb_user()`
- `src/modules/mod.rs` — replace rayon ESC8 probe with `spawn_blocking` + `join_all`
- `src/modules/adcs/esc8.rs` — fix malformed NTLM Type 1 blob

Total: 5 files, +70 / -23.
